### PR TITLE
OpenRTB v2.6-202309

### DIFF
--- a/openrtb2/audio.go
+++ b/openrtb2/audio.go
@@ -257,6 +257,15 @@ type Audio struct {
 	NVol *adcom1.VolumeNormalizationMode `json:"nvol,omitempty"`
 
 	// Attribute:
+	//   durfloors
+	// Type:
+	//   object array
+	// Description:
+	//   An array of DurFloors objects (Section 3.2.35) indicating the floor
+	//   prices for video creatives of various durations that the buyer may bid with.
+	DurFloors []DurFloors `json:"durfloors,omitempty"`
+
+	// Attribute:
 	//   ext
 	// Type:
 	//   object

--- a/openrtb2/bid_request.go
+++ b/openrtb2/bid_request.go
@@ -8,7 +8,7 @@ import (
 
 // 3.2.1 Object: BidRequest
 //
-// The top-level bid request object contains a globally unique bid request or auction ID.
+// The top-level bid request object contains an exchange unique bid request or auction ID.
 // This id attribute is required as is at least one impression object (Section 3.2.4).
 // Other attributes in this top-level object establish rules and restrictions that apply to all impressions being offered.
 //
@@ -22,7 +22,9 @@ type BidRequest struct {
 	// Type:
 	//   string; required
 	// Description:
-	//   Unique ID of the bid request, provided by the exchange.
+	//   ID of the bid request, assigned by the exchange, and unique for the
+	//   exchange’s subsequent tracking of the responses. The exchange may use
+	//   different values for different recipients.
 	ID string `json:"id"`
 
 	// Attribute:
@@ -183,6 +185,17 @@ type BidRequest struct {
 	WLangB []string `json:"wlangb,omitempty"`
 
 	// Attribute:
+	//   acat
+	// Type:
+	//   string array
+	// Description:
+	//   Allowed advertiser categories using the specified category taxonomy.
+	//   The taxonomy to be used is defined by the cattax field. If no cattax
+	//   field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of
+	//   acat or bcat should be present.
+	ACat []string `json:"acat,omitempty"`
+
+	// Attribute:
 	//   bcat
 	// Type:
 	//   string array
@@ -191,7 +204,7 @@ type BidRequest struct {
 	//   category taxonomy.
 	//   The taxonomy to be used is defined by the cattax field. If no
 	//   cattax field is supplied IAB Content Category Taxonomy 1.0 is
-	//   assumed.
+	//   assumed.  Only one of acat or bcat should be present.
 	BCat []string `json:"bcat,omitempty"`
 
 	// Attribute:

--- a/openrtb2/deal.go
+++ b/openrtb2/deal.go
@@ -94,7 +94,7 @@ type Deal struct {
 	// Description:
 	//   An array of DurFloors objects (Section 3.2.35) indicating the floor
 	//   prices for video creatives of various durations that the buyer may bid with.
-	DurFloors [] `json:"durfloors,omitempty"`
+	DurFloors []DurFloors `json:"durfloors,omitempty"`
 
 	// Attribute:
 	//   wadomain

--- a/openrtb2/deal.go
+++ b/openrtb2/deal.go
@@ -92,8 +92,9 @@ type Deal struct {
 	// Type:
 	//   object array
 	// Description:
-	//   An array of DurFloors objects (Section 3.2.35) indicating the floor
-	//   prices for video creatives of various durations that the buyer may bid with.
+	//   Container for floor price by duration information, to be used if a
+	//   given deal is eligible for video or audio demand. An array of DurFloors
+	//   objects (see Section 3.2.35).
 	DurFloors []DurFloors `json:"durfloors,omitempty"`
 
 	// Attribute:

--- a/openrtb2/deal.go
+++ b/openrtb2/deal.go
@@ -32,7 +32,9 @@ type Deal struct {
 	// Description:
 	//   Currency specified using ISO-4217 alpha codes. This may be
 	//   different from bid currency returned by bidder if this is
-	//   allowed by the exchange.
+	//   allowed by the exchange. This field does not inherit from
+	//   imp.bidfloorcur; it is either explicitly specified or
+	//   defaults to USD.
 	BidFloorCur string `json:"bidfloorcur,omitempty"`
 
 	// Attribute:
@@ -66,6 +68,39 @@ type Deal struct {
 	//   bid on this deal. Omission implies no advertiser restrictions.
 	WADomain []string `json:"wadomain,omitempty"`
 
+	// Attribute:
+	//   guar
+	// Type:
+	//   integer, default 0
+	// Description:
+	//   Indicates that the deal is of type guaranteed and the bidder must
+	//   bid on the deal, where 0 = not a guaranteed deal, 1 = guaranteed deal.
+	Guar int8 `json:"guar,omitempty"` // convert to an enum?
+
+	// Attribute:
+	//   mincpmpersec
+	// Type:
+	//   float
+	// Definition:
+	//   Minimum CPM per second. This is a price floor for video or audio
+	//   impression opportunities, relative to the duration of bids an
+	//   advertiser may submit.
+	MinCPMPerSec float64 `json:"mincpmpersec,omitempty"`
+
+	// Attribute:
+	//   durfloors
+	// Type:
+	//   object array
+	// Description:
+	//   An array of DurFloors objects (Section 3.2.35) indicating the floor
+	//   prices for video creatives of various durations that the buyer may bid with.
+	DurFloors [] `json:"durfloors,omitempty"`
+
+	// Attribute:
+	//   wadomain
+	// Type:
+	//   string array
+	// Description:
 	// Attribute:
 	//   ext
 	// Type:

--- a/openrtb2/deal.go
+++ b/openrtb2/deal.go
@@ -75,7 +75,7 @@ type Deal struct {
 	// Description:
 	//   Indicates that the deal is of type guaranteed and the bidder must
 	//   bid on the deal, where 0 = not a guaranteed deal, 1 = guaranteed deal.
-	Guar *int8 `json:"guar,omitempty"`
+	Guar int8 `json:"guar,omitempty"`
 
 	// Attribute:
 	//   mincpmpersec

--- a/openrtb2/deal.go
+++ b/openrtb2/deal.go
@@ -75,7 +75,7 @@ type Deal struct {
 	// Description:
 	//   Indicates that the deal is of type guaranteed and the bidder must
 	//   bid on the deal, where 0 = not a guaranteed deal, 1 = guaranteed deal.
-	Guar int8 `json:"guar,omitempty"` // convert to an enum?
+	Guar *int8 `json:"guar,omitempty"`
 
 	// Attribute:
 	//   mincpmpersec

--- a/openrtb2/durfloors.go
+++ b/openrtb2/durfloors.go
@@ -11,6 +11,7 @@ import (
 // There are no explicit constraints on the defined ranges, nor guarantees that they don't overlap.
 // In cases where multiple ranges may apply, it is up to the buyer and seller to coordinate on which floor is applicable.
 type DurFloors struct {
+
 	// Attribute:
 	//   mindur
 	// Type:

--- a/openrtb2/durfloors.go
+++ b/openrtb2/durfloors.go
@@ -1,0 +1,52 @@
+package openrtb2
+
+import (
+	"encoding/json"
+)
+
+// Object: DurFloors
+//
+// This object allows sellers to specify price floors for video and audio creatives, whose price varies based on time.
+// For example: 1-15 seconds at a floor of $5; 16-30 seconds at a floor of $10, > 31 seconds at a floor of $20.
+// There are no explicit constraints on the defined ranges, nor guarantees that they don't overlap.
+// In cases where multiple ranges may apply, it is up to the buyer and seller to coordinate on which floor is applicable.
+type DurFloors struct {
+	// Attribute:
+	//   mindur
+	// Type:
+	//   integer
+	// Description:
+	//   An integer indicating the low end of a duration range. If this
+	//   value is missing, the low end is unbounded. Either mindur or maxdur
+	//   is required, but not both.
+	MinDur int64 `json:"mindur,omitempty"`
+
+	// Attribute:
+	//   maxdur
+	// Type:
+	//   integer
+	// Description:
+	//   An integer indicating the high end of a duration range. If this
+	//   value is missing, the high end is unbounded. Either mindur or maxdur
+	//   is required, but not both.
+	MaxDur int64 `json:"maxdur,omitempty"`
+
+	// Attribute:
+	//   bidfloor
+	// Type:
+	//   float; default 0
+	// Description:
+	//   Minimum bid for a given impression opportunity, if bidding with a
+	//   creative in this duration range, expressed in CPM. For any creatives
+	//   whose durations are outside of the defined min/max, the bidfloor at
+	//   the Imp level will serve as the default floor.
+	BidFloor float64 `json:"bidfloor,omitempty"`
+
+	// Attribute:
+	//   ext
+	// Type:
+	//   object
+	// Definition:
+	//   Placeholder for vendor specific extensions to this object.
+	Ext json.RawMessage `json:"ext,omitempty"`
+}

--- a/openrtb2/imp.go
+++ b/openrtb2/imp.go
@@ -130,7 +130,8 @@ type Imp struct {
 	// Description:
 	//   Currency specified using ISO-4217 alpha codes. This may be
 	//   different from bid currency returned by bidder if this is
-	//   allowed by the exchange.
+	//   allowed by the exchange. This currency sets the default for
+	//   all floors specified in the Imp object.
 	BidFloorCur string `json:"bidfloorcur,omitempty"`
 
 	// Attribute:

--- a/openrtb2/refresh.go
+++ b/openrtb2/refresh.go
@@ -4,6 +4,7 @@ import "encoding/json"
 
 // Object: Refresh
 type Refresh struct {
+
 	// Attribute:
 	//   refsettings
 	// Type:

--- a/openrtb2/refsettings.go
+++ b/openrtb2/refsettings.go
@@ -10,6 +10,7 @@ import (
 //
 // Information on how often and what triggers an ad slot being refreshed.
 type RefSettings struct {
+
 	// Attribute:
 	//   reftype
 	// Type:

--- a/openrtb2/site.go
+++ b/openrtb2/site.go
@@ -40,7 +40,7 @@ type Site struct {
 	// Attribute:
 	//   cattax
 	// Type:
-	//   integer
+	//   integer; default 1
 	// Description:
 	//   The taxonomy in use. Refer to the AdCOM list List: Category
 	//   Taxonomies for values. If no cattax field is supplied IAB Content

--- a/openrtb2/video.go
+++ b/openrtb2/video.go
@@ -375,6 +375,15 @@ type Video struct {
 	CompanionType []adcom1.CompanionType `json:"companiontype,omitempty"`
 
 	// Attribute:
+	//   durfloors
+	// Type:
+	//   object array
+	// Description:
+	//   An array of DurFloors objects (Section 3.2.35) indicating the floor
+	//   prices for video creatives of various durations that the buyer may bid with.
+	DurFloors []DurFloors `json:"durfloors,omitempty"`
+
+	// Attribute:
 	//   ext
 	// Type:
 	//   object


### PR DESCRIPTION
Updates the object model for [OpenRTB 2.6-202309](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/releases/tag/2.6-202309) release.