### PR TITLE
OpenRTB v2.6-202402

### DIFF
--- a/adcom1/pod_dedupe.go
+++ b/adcom1/pod_dedupe.go
@@ -1,0 +1,13 @@
+package adcom1
+
+// PodDedupe
+//
+// Types of pod deduplication settings.
+type PodDedupe int8
+
+const (
+	PodDedupeADomain      PodDedupe = 1
+	PodDedupeIABCategory  PodDedupe = 2
+	PodDedupeCreativeID   PodDedupe = 3
+	PodDedupeMediafileURL PodDedupe = 4
+)

--- a/openrtb2/video.go
+++ b/openrtb2/video.go
@@ -377,7 +377,7 @@ type Video struct {
 	// Attribute:
 	//   poddedupe
 	// Type:
-	//   enum array
+	//   enum array; provisional
 	// Description:
 	//   Indicates pod deduplication settings that will be applied to bid
 	//   responses. Refer to List: Pod Deduplication in AdCOM 1.0.

--- a/openrtb2/video.go
+++ b/openrtb2/video.go
@@ -375,6 +375,15 @@ type Video struct {
 	CompanionType []adcom1.CompanionType `json:"companiontype,omitempty"`
 
 	// Attribute:
+	//   poddedupe
+	// Type:
+	//   enum array
+	// Description:
+	//   Indicates pod deduplication settings that will be applied to bid
+	//   responses. Refer to List: Pod Deduplication in AdCOM 1.0.
+	PodDedupe []adcom1.PodDedupe `json:"poddedupe,omitempty"`
+
+	// Attribute:
 	//   durfloors
 	// Type:
 	//   object array


### PR DESCRIPTION
Updates the object model for [OpenRTB 2.6-2024002](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/releases/tag/2.6-202402) release.