### PR TITLE
Fix audio/video placement playmethod type

### DIFF
--- a/adcom1/audio_placement.go
+++ b/adcom1/audio_placement.go
@@ -40,11 +40,11 @@ type AudioPlacement struct {
 	// Attribute:
 	//   playmethod
 	// Type:
-	//   integer
+	//   integer array
 	// Definition:
-	//   Playback method in use for this placement.
+	//   Playback method(s) in use for this placement.
 	//   Refer to List: Playback Methods.
-	PlayMethod PlaybackMethod `json:"playmethod,omitempty"`
+	PlayMethod []PlaybackMethod `json:"playmethod,omitempty"`
 
 	// Attribute:
 	//   playend

--- a/adcom1/video_placement.go
+++ b/adcom1/video_placement.go
@@ -60,11 +60,11 @@ type VideoPlacement struct {
 	// Attribute:
 	//   playmethod
 	// Type:
-	//   integer
+	//   integer array
 	// Definition:
-	//   Playback method in use for this placement.
+	//   Playback method(s) in use for this placement.
 	//   Refer to List: Playback Methods.
-	PlayMethod PlaybackMethod `json:"playmethod,omitempty"`
+	PlayMethod []PlaybackMethod `json:"playmethod,omitempty"`
 
 	// Attribute:
 	//   playend


### PR DESCRIPTION
Type for `AudioPlacement.PlayMethod` and `VideoPlacement.PlayMethod` was changed to an array in InteractiveAdvertisingBureau/AdCOM#31.