### PR TITLE
Implement deep copy functionality for various OpenRTB structures and github actions CI

### DIFF
--- a/github/workflows/ci.yml
+++ b/github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Go Tests
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+        cache: true
+        
+    - name: Run Tests
+      run: go test -v ./...
+
+    - name: Run Tests with Race Detector
+      run: go test -race -v ./...

--- a/openrtb2/app.go
+++ b/openrtb2/app.go
@@ -178,3 +178,31 @@ type App struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of App
+func (a *App) Clone() *App {
+	if a == nil {
+		return nil
+	}
+
+	clone := *a
+
+	// Clone pointer fields
+	clone.PrivacyPolicy = cloneInt8Ptr(a.PrivacyPolicy)
+	clone.Paid = cloneInt8Ptr(a.Paid)
+
+	// Clone string slices
+	clone.Cat = cloneStringSlice(a.Cat)
+	clone.SectionCat = cloneStringSlice(a.SectionCat)
+	clone.PageCat = cloneStringSlice(a.PageCat)
+	clone.KwArray = cloneStringSlice(a.KwArray)
+
+	// Clone pointer objects
+	clone.Publisher = a.Publisher.Clone()
+	clone.Content = a.Content.Clone()
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(a.Ext)
+
+	return &clone
+}

--- a/openrtb2/app_test.go
+++ b/openrtb2/app_test.go
@@ -1,0 +1,119 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestApp_Clone(t *testing.T) {
+	var (
+		privacyPolicy int8 = 1
+		paid          int8 = 1
+	)
+
+	tests := []struct {
+		name string
+		a    *App
+	}{
+		{
+			name: "nil app",
+			a:    nil,
+		},
+		{
+			name: "empty app",
+			a:    &App{},
+		},
+		{
+			name: "fully populated app",
+			a: &App{
+				ID:            "app1",
+				Name:          "Test App",
+				Bundle:        "com.test.app",
+				Domain:        "test.com",
+				StoreURL:      "https://play.google.com/store/apps/details?id=com.test.app",
+				CatTax:        adcom1.CategoryTaxonomy(1),
+				Cat:           []string{"IAB1", "IAB2"},
+				SectionCat:    []string{"IAB3", "IAB4"},
+				PageCat:       []string{"IAB5", "IAB6"},
+				Ver:           "1.0",
+				PrivacyPolicy: &privacyPolicy,
+				Paid:          &paid,
+				Publisher: &Publisher{
+					ID:   "pub1",
+					Name: "Publisher 1",
+					Ext:  json.RawMessage(`{"key": "value"}`),
+				},
+				Content: &Content{
+					ID:    "content1",
+					Title: "Test Content",
+					Ext:   json.RawMessage(`{"key": "value"}`),
+				},
+				Keywords:               "test,app",
+				KwArray:                []string{"test", "app"},
+				InventoryPartnerDomain: "partner.com",
+				Ext:                    json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.a.Clone()
+
+			if tt.a == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil App")
+				}
+				return
+			}
+
+			// Test pointer fields
+			if tt.a.PrivacyPolicy != nil {
+				orig := *tt.a.PrivacyPolicy
+				*tt.a.PrivacyPolicy = 0
+				if *clone.PrivacyPolicy != orig {
+					t.Error("Clone() should create deep copy of PrivacyPolicy")
+				}
+			}
+
+			// Test string slices
+			if len(tt.a.Cat) > 0 {
+				original := tt.a.Cat[0]
+				tt.a.Cat[0] = "modified"
+				if clone.Cat[0] != original {
+					t.Error("Clone() should create deep copy of Cat slice")
+				}
+			}
+
+			// Test Publisher
+			if tt.a.Publisher != nil {
+				origName := tt.a.Publisher.Name
+				tt.a.Publisher.Name = "modified"
+				if clone.Publisher.Name != origName {
+					t.Error("Clone() should create deep copy of Publisher")
+				}
+			}
+
+			// Test Content
+			if tt.a.Content != nil {
+				origTitle := tt.a.Content.Title
+				tt.a.Content.Title = "modified"
+				if clone.Content.Title != origTitle {
+					t.Error("Clone() should create deep copy of Content")
+				}
+			}
+
+			// Test deep copy of extension
+			if tt.a.Ext != nil {
+				orig := string(tt.a.Ext)
+				tt.a.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/audio.go
+++ b/openrtb2/audio.go
@@ -273,3 +273,81 @@ type Audio struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Audio
+func (a *Audio) Clone() *Audio {
+	if a == nil {
+		return nil
+	}
+
+	clone := *a
+
+	// Clone string slices
+	clone.MIMEs = cloneStringSlice(a.MIMEs)
+
+	// Clone integer slices
+	if a.RqdDurs != nil {
+		clone.RqdDurs = make([]int64, len(a.RqdDurs))
+		copy(clone.RqdDurs, a.RqdDurs)
+	}
+
+	// Clone pointer fields
+	clone.StartDelay = cloneStartDelayPtr(a.StartDelay)
+	clone.Stitched = cloneInt8Ptr(a.Stitched)
+	clone.NVol = cloneVolumeModePtr(a.NVol)
+
+	// Clone adcom1 type slices
+	if a.Protocols != nil {
+		clone.Protocols = make([]adcom1.MediaCreativeSubtype, len(a.Protocols))
+		copy(clone.Protocols, a.Protocols)
+	}
+
+	if a.BAttr != nil {
+		clone.BAttr = make([]adcom1.CreativeAttribute, len(a.BAttr))
+		copy(clone.BAttr, a.BAttr)
+	}
+
+	if a.Delivery != nil {
+		clone.Delivery = make([]adcom1.DeliveryMethod, len(a.Delivery))
+		copy(clone.Delivery, a.Delivery)
+	}
+
+	if a.API != nil {
+		clone.API = make([]adcom1.APIFramework, len(a.API))
+		copy(clone.API, a.API)
+	}
+
+	if a.CompanionType != nil {
+		clone.CompanionType = make([]adcom1.CompanionType, len(a.CompanionType))
+		copy(clone.CompanionType, a.CompanionType)
+	}
+
+	// Clone Banner slice with deep copy
+	if a.CompanionAd != nil {
+		clone.CompanionAd = make([]Banner, len(a.CompanionAd))
+		for i := range a.CompanionAd {
+			clone.CompanionAd[i] = *a.CompanionAd[i].Clone()
+		}
+	}
+
+	// Clone DurFloors slice
+	if a.DurFloors != nil {
+		clone.DurFloors = make([]DurFloors, len(a.DurFloors))
+		for i := range a.DurFloors {
+			clone.DurFloors[i] = *a.DurFloors[i].Clone()
+		}
+	}
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(a.Ext)
+
+	return &clone
+}
+
+func cloneVolumeModePtr(v *adcom1.VolumeNormalizationMode) *adcom1.VolumeNormalizationMode {
+	if v == nil {
+		return nil
+	}
+	clone := *v
+	return &clone
+}

--- a/openrtb2/audio_test.go
+++ b/openrtb2/audio_test.go
@@ -1,0 +1,125 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestAudio_Clone(t *testing.T) {
+	var (
+		stitched   int8 = 1
+		startDelay      = adcom1.StartDelay(0)
+		nvol            = adcom1.VolumeNormalizationMode(1)
+	)
+
+	tests := []struct {
+		name string
+		a    *Audio
+	}{
+		{
+			name: "nil audio",
+			a:    nil,
+		},
+		{
+			name: "empty audio",
+			a:    &Audio{},
+		},
+		{
+			name: "fully populated audio",
+			a: &Audio{
+				MIMEs:        []string{"audio/mp4"},
+				MinDuration:  15,
+				MaxDuration:  30,
+				PodDur:       90,
+				Protocols:    []adcom1.MediaCreativeSubtype{1, 2},
+				StartDelay:   &startDelay,
+				RqdDurs:      []int64{15, 30},
+				PodID:        "pod123",
+				PodSeq:       1,
+				Sequence:     1,
+				SlotInPod:    1,
+				MinCPMPerSec: 1.5,
+				BAttr:        []adcom1.CreativeAttribute{1, 2},
+				MaxExtended:  60,
+				MinBitrate:   1000,
+				MaxBitrate:   2000,
+				Delivery:     []adcom1.DeliveryMethod{1, 2},
+				CompanionAd: []Banner{
+					{
+						ID:  "banner1",
+						Ext: json.RawMessage(`{"key": "value"}`),
+					},
+				},
+				API:           []adcom1.APIFramework{1, 2},
+				CompanionType: []adcom1.CompanionType{1, 2},
+				MaxSeq:        3,
+				Feed:          1,
+				Stitched:      &stitched,
+				NVol:          &nvol,
+				DurFloors:     []DurFloors{{MinDur: 15, BidFloor: 5.0}},
+				Ext:           json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.a.Clone()
+
+			if tt.a == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Audio")
+				}
+				return
+			}
+
+			// Test deep copy of extension
+			if tt.a.Ext != nil {
+				orig := string(tt.a.Ext)       // Store original as string
+				tt.a.Ext[0] = 'X'              // Modify original
+				clonedStr := string(clone.Ext) // Get clone as string
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot:  %q", orig, clonedStr)
+				}
+			}
+
+			// Test pointer fields
+			if tt.a.Stitched != nil {
+				origStitched := *tt.a.Stitched
+				*tt.a.Stitched = 0
+				if *clone.Stitched != origStitched {
+					t.Error("Clone() should create deep copy of Stitched pointer")
+				}
+			}
+
+			// Test slices
+			if len(tt.a.MIMEs) > 0 {
+				original := tt.a.MIMEs[0]
+				tt.a.MIMEs[0] = "modified"
+				if clone.MIMEs[0] != original {
+					t.Error("Clone() should create deep copy of MIMEs slice")
+				}
+			}
+
+			// Test CompanionAd slice
+			if len(tt.a.CompanionAd) > 0 {
+				origID := tt.a.CompanionAd[0].ID
+				tt.a.CompanionAd[0].ID = "modified"
+				if clone.CompanionAd[0].ID != origID {
+					t.Error("Clone() should create deep copy of CompanionAd")
+				}
+			}
+
+			// Test DurFloors slice
+			if len(tt.a.DurFloors) > 0 {
+				origFloor := tt.a.DurFloors[0].BidFloor
+				tt.a.DurFloors[0].BidFloor = 999.99
+				if clone.DurFloors[0].BidFloor != origFloor {
+					t.Error("Clone() should create deep copy of DurFloors")
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/banner.go
+++ b/openrtb2/banner.go
@@ -180,3 +180,62 @@ type Banner struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Banner
+func (b *Banner) Clone() *Banner {
+	if b == nil {
+		return nil
+	}
+
+	clone := *b
+
+	// Clone Format slice
+	if b.Format != nil {
+		clone.Format = make([]Format, len(b.Format))
+		for i := range b.Format {
+			clone.Format[i] = *b.Format[i].Clone()
+		}
+	}
+
+	// Clone pointer fields
+	clone.W = cloneInt64Ptr(b.W)
+	clone.H = cloneInt64Ptr(b.H)
+	clone.Pos = clonePlacementPositionPtr(b.Pos)
+	clone.Vcm = cloneInt8Ptr(b.Vcm)
+
+	// Clone slices using make and copy for better performance
+	if b.BType != nil {
+		clone.BType = make([]BannerAdType, len(b.BType))
+		copy(clone.BType, b.BType)
+	}
+
+	if b.BAttr != nil {
+		clone.BAttr = make([]adcom1.CreativeAttribute, len(b.BAttr))
+		copy(clone.BAttr, b.BAttr)
+	}
+
+	clone.MIMEs = cloneStringSlice(b.MIMEs)
+
+	if b.ExpDir != nil {
+		clone.ExpDir = make([]adcom1.ExpandableDirection, len(b.ExpDir))
+		copy(clone.ExpDir, b.ExpDir)
+	}
+
+	if b.API != nil {
+		clone.API = make([]adcom1.APIFramework, len(b.API))
+		copy(clone.API, b.API)
+	}
+
+	// Clone RawMessage
+	clone.Ext = cloneRawMessage(b.Ext)
+
+	return &clone
+}
+
+func clonePlacementPositionPtr(p *adcom1.PlacementPosition) *adcom1.PlacementPosition {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	return &clone
+}

--- a/openrtb2/banner_test.go
+++ b/openrtb2/banner_test.go
@@ -1,0 +1,121 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestBanner_Clone(t *testing.T) {
+	var (
+		w   int64 = 300
+		h   int64 = 250
+		pos       = adcom1.PlacementPosition(1)
+		vcm int8  = 1
+	)
+
+	tests := []struct {
+		name string
+		b    *Banner
+	}{
+		{
+			name: "nil banner",
+			b:    nil,
+		},
+		{
+			name: "empty banner",
+			b:    &Banner{},
+		},
+		{
+			name: "fully populated banner",
+			b: &Banner{
+				Format: []Format{
+					{
+						W:      300,
+						H:      250,
+						WRatio: 16,
+						HRatio: 9,
+						WMin:   100,
+						Ext:    json.RawMessage(`{"key": "value"}`),
+					},
+				},
+				W:        &w,
+				H:        &h,
+				WMax:     1000,
+				HMax:     1000,
+				WMin:     0,
+				HMin:     0,
+				BType:    []BannerAdType{1, 2},
+				BAttr:    []adcom1.CreativeAttribute{1, 2},
+				Pos:      &pos,
+				MIMEs:    []string{"image/jpeg", "image/png"},
+				TopFrame: 1,
+				ExpDir:   []adcom1.ExpandableDirection{1, 2},
+				API:      []adcom1.APIFramework{1, 2},
+				ID:       "test",
+				Vcm:      &vcm,
+				Ext:      json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.b.Clone()
+
+			if tt.b == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Banner")
+				}
+				return
+			}
+
+			// Verify initial equality
+			if !reflect.DeepEqual(clone, tt.b) {
+				t.Errorf("Clone() = %v, want %v", clone, tt.b)
+			}
+
+			// Test deep copy of Format slice
+			if tt.b.Format != nil {
+				origFormat := make([]Format, len(tt.b.Format))
+				copy(origFormat, tt.b.Format)
+				tt.b.Format[0].W = 999
+				if !reflect.DeepEqual(clone.Format, origFormat) {
+					t.Error("Clone() should create a deep copy of Format slice")
+				}
+			}
+
+			// Test deep copy of pointer fields
+			if tt.b.W != nil {
+				origW := *tt.b.W
+				*tt.b.W = 999
+				if *clone.W != origW {
+					t.Error("Clone() should create a deep copy of W pointer")
+				}
+			}
+
+			// Test deep copy of extension
+			if tt.b.Ext != nil {
+				orig := string(tt.b.Ext)       // Store original as string
+				tt.b.Ext[0] = 'X'              // Modify original
+				clonedStr := string(clone.Ext) // Get clone as string
+
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot:  %q", orig, clonedStr)
+				}
+			}
+
+			// Test deep copy of slices
+			if len(tt.b.MIMEs) > 0 {
+				origMIMEs := make([]string, len(tt.b.MIMEs))
+				copy(origMIMEs, tt.b.MIMEs)
+				tt.b.MIMEs[0] = "modified"
+				if !reflect.DeepEqual(clone.MIMEs, origMIMEs) {
+					t.Error("Clone() should create a deep copy of MIMEs slice")
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/bid_request.go
+++ b/openrtb2/bid_request.go
@@ -263,3 +263,109 @@ type BidRequest struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the BidRequest object.
+func (br *BidRequest) Clone() *BidRequest {
+	if br == nil {
+		return nil
+	}
+
+	clone := *br
+
+	// Deep copy Imp slice
+	if br.Imp != nil {
+		clone.Imp = make([]Imp, len(br.Imp))
+		for i := range br.Imp {
+			clone.Imp[i] = *br.Imp[i].Clone()
+		}
+	}
+
+	// Deep copy Site
+	if br.Site != nil {
+		clone.Site = br.Site.Clone()
+	}
+
+	// Deep copy App
+	if br.App != nil {
+		clone.App = br.App.Clone()
+	}
+
+	// Deep copy DOOH
+	if br.DOOH != nil {
+		clone.DOOH = br.DOOH.Clone()
+	}
+
+	// Deep copy Device
+	if br.Device != nil {
+		clone.Device = br.Device.Clone()
+	}
+
+	// Deep copy User
+	if br.User != nil {
+		clone.User = br.User.Clone()
+	}
+
+	// Deep copy string slices
+	if br.WSeat != nil {
+		clone.WSeat = make([]string, len(br.WSeat))
+		copy(clone.WSeat, br.WSeat)
+	}
+
+	if br.BSeat != nil {
+		clone.BSeat = make([]string, len(br.BSeat))
+		copy(clone.BSeat, br.BSeat)
+	}
+
+	if br.Cur != nil {
+		clone.Cur = make([]string, len(br.Cur))
+		copy(clone.Cur, br.Cur)
+	}
+
+	if br.WLang != nil {
+		clone.WLang = make([]string, len(br.WLang))
+		copy(clone.WLang, br.WLang)
+	}
+
+	if br.WLangB != nil {
+		clone.WLangB = make([]string, len(br.WLangB))
+		copy(clone.WLangB, br.WLangB)
+	}
+
+	if br.ACat != nil {
+		clone.ACat = make([]string, len(br.ACat))
+		copy(clone.ACat, br.ACat)
+	}
+
+	if br.BCat != nil {
+		clone.BCat = make([]string, len(br.BCat))
+		copy(clone.BCat, br.BCat)
+	}
+
+	if br.BAdv != nil {
+		clone.BAdv = make([]string, len(br.BAdv))
+		copy(clone.BAdv, br.BAdv)
+	}
+
+	if br.BApp != nil {
+		clone.BApp = make([]string, len(br.BApp))
+		copy(clone.BApp, br.BApp)
+	}
+
+	// Deep copy Source
+	if br.Source != nil {
+		clone.Source = br.Source.Clone()
+	}
+
+	// Deep copy Regs
+	if br.Regs != nil {
+		clone.Regs = br.Regs.Clone()
+	}
+
+	// Deep copy ext
+	if br.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(br.Ext))
+		copy(clone.Ext, br.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/bid_request_clone_test.go
+++ b/openrtb2/bid_request_clone_test.go
@@ -1,0 +1,274 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestBidRequest_Clone(t *testing.T) {
+	secure := int8(1)
+	width := int64(300)
+	height := int64(250)
+
+	tests := []struct {
+		name string
+		br   *BidRequest
+	}{
+		{
+			name: "nil bid request",
+			br:   nil,
+		},
+		{
+			name: "empty bid request",
+			br:   &BidRequest{},
+		},
+		{
+			name: "fully populated bid request",
+			br: &BidRequest{
+				ID: "bid1",
+				Imp: []Imp{
+					{
+						ID: "imp1",
+						Banner: &Banner{
+							W:   &width,
+							H:   &height,
+							Ext: json.RawMessage(`{"banner_key":"value"}`),
+						},
+						Secure: &secure,
+						Ext:    json.RawMessage(`{"imp_key":"value"}`),
+					},
+				},
+				Site: &Site{
+					ID:   "site1",
+					Name: "example.com",
+					Publisher: &Publisher{
+						ID:   "pub1",
+						Name: "Example Publisher",
+						Ext:  json.RawMessage(`{"publisher_key":"value"}`),
+					},
+					Ext: json.RawMessage(`{"site_key":"value"}`),
+				},
+				App: &App{
+					ID:   "app1",
+					Name: "Example App",
+					Publisher: &Publisher{
+						ID:   "pub2",
+						Name: "Example App Publisher",
+						Ext:  json.RawMessage(`{"publisher_key":"value"}`),
+					},
+					Ext: json.RawMessage(`{"app_key":"value"}`),
+				},
+				DOOH: &DOOH{
+					ID:   "dooh1",
+					Name: "Times Square Display",
+					Ext:  json.RawMessage(`{"dooh_key":"value"}`),
+				},
+				Device: &Device{
+					UA:    "test-user-agent",
+					IP:    "192.168.1.1",
+					Model: "iPhone",
+					OS:    "iOS",
+					OSV:   "14.0",
+					Make:  "Apple",
+					Ext:   json.RawMessage(`{"device_key":"value"}`),
+				},
+				User: &User{
+					ID:     "user1",
+					Yob:    1990,
+					Gender: "M",
+					Ext:    json.RawMessage(`{"user_key":"value"}`),
+				},
+				Test:    1,
+				AT:      2,
+				TMax:    500,
+				WSeat:   []string{"seat1", "seat2"},
+				BSeat:   []string{"seat3", "seat4"},
+				AllImps: 1,
+				Cur:     []string{"USD", "EUR"},
+				WLang:   []string{"en", "es"},
+				WLangB:  []string{"en-US", "es-ES"},
+				ACat:    []string{"IAB1", "IAB2"},
+				BCat:    []string{"IAB3", "IAB4"},
+				CatTax:  adcom1.CatTaxIABContent10,
+				BAdv:    []string{"adv1.com", "adv2.com"},
+				BApp:    []string{"com.example.app1", "com.example.app2"},
+				Source: &Source{
+					FD:     &secure,
+					TID:    "tid1",
+					PChain: "pchain1",
+					Ext:    json.RawMessage(`{"source_key":"value"}`),
+				},
+				Regs: &Regs{
+					COPPA: 1,
+					Ext:   json.RawMessage(`{"regs_key":"value"}`),
+				},
+				Ext: json.RawMessage(`{"request_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.br.Clone()
+
+			if tt.br == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil BidRequest")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.br.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.br.ID)
+			}
+			if clone.Test != tt.br.Test {
+				t.Errorf("Clone() Test = %v, want %v", clone.Test, tt.br.Test)
+			}
+			if clone.AT != tt.br.AT {
+				t.Errorf("Clone() AT = %v, want %v", clone.AT, tt.br.AT)
+			}
+			if clone.TMax != tt.br.TMax {
+				t.Errorf("Clone() TMax = %v, want %v", clone.TMax, tt.br.TMax)
+			}
+			if clone.AllImps != tt.br.AllImps {
+				t.Errorf("Clone() AllImps = %v, want %v", clone.AllImps, tt.br.AllImps)
+			}
+			if clone.CatTax != tt.br.CatTax {
+				t.Errorf("Clone() CatTax = %v, want %v", clone.CatTax, tt.br.CatTax)
+			}
+
+			// Test Imp slice
+			if len(tt.br.Imp) > 0 {
+				if len(clone.Imp) != len(tt.br.Imp) {
+					t.Errorf("Clone() Imp length = %v, want %v", len(clone.Imp), len(tt.br.Imp))
+				}
+				originalID := tt.br.Imp[0].ID
+				tt.br.Imp[0].ID = "modified"
+				if clone.Imp[0].ID != originalID {
+					t.Error("Clone() should create deep copy of Imp")
+				}
+			}
+
+			// Test Site
+			if tt.br.Site != nil {
+				if clone.Site == tt.br.Site {
+					t.Error("Clone() should create a new pointer for Site")
+				}
+				originalID := tt.br.Site.ID
+				tt.br.Site.ID = "modified"
+				if clone.Site.ID != originalID {
+					t.Error("Clone() should create deep copy of Site")
+				}
+			}
+
+			// Test App
+			if tt.br.App != nil {
+				if clone.App == tt.br.App {
+					t.Error("Clone() should create a new pointer for App")
+				}
+				originalID := tt.br.App.ID
+				tt.br.App.ID = "modified"
+				if clone.App.ID != originalID {
+					t.Error("Clone() should create deep copy of App")
+				}
+			}
+
+			// Test DOOH
+			if tt.br.DOOH != nil {
+				if clone.DOOH == tt.br.DOOH {
+					t.Error("Clone() should create a new pointer for DOOH")
+				}
+				originalID := tt.br.DOOH.ID
+				tt.br.DOOH.ID = "modified"
+				if clone.DOOH.ID != originalID {
+					t.Error("Clone() should create deep copy of DOOH")
+				}
+			}
+
+			// Test Device
+			if tt.br.Device != nil {
+				if clone.Device == tt.br.Device {
+					t.Error("Clone() should create a new pointer for Device")
+				}
+				originalUA := tt.br.Device.UA
+				tt.br.Device.UA = "modified"
+				if clone.Device.UA != originalUA {
+					t.Error("Clone() should create deep copy of Device")
+				}
+			}
+
+			// Test User
+			if tt.br.User != nil {
+				if clone.User == tt.br.User {
+					t.Error("Clone() should create a new pointer for User")
+				}
+				originalID := tt.br.User.ID
+				tt.br.User.ID = "modified"
+				if clone.User.ID != originalID {
+					t.Error("Clone() should create deep copy of User")
+				}
+			}
+
+			// Test string slices
+			testStringSlice := func(name string, original, cloned []string) {
+				if len(original) > 0 {
+					if len(cloned) != len(original) {
+						t.Errorf("Clone() %s length = %v, want %v", name, len(cloned), len(original))
+					}
+					originalValue := original[0]
+					original[0] = "modified"
+					if cloned[0] != originalValue {
+						t.Errorf("Clone() should create deep copy of %s", name)
+					}
+				}
+			}
+
+			testStringSlice("WSeat", tt.br.WSeat, clone.WSeat)
+			testStringSlice("BSeat", tt.br.BSeat, clone.BSeat)
+			testStringSlice("Cur", tt.br.Cur, clone.Cur)
+			testStringSlice("WLang", tt.br.WLang, clone.WLang)
+			testStringSlice("WLangB", tt.br.WLangB, clone.WLangB)
+			testStringSlice("ACat", tt.br.ACat, clone.ACat)
+			testStringSlice("BCat", tt.br.BCat, clone.BCat)
+			testStringSlice("BAdv", tt.br.BAdv, clone.BAdv)
+			testStringSlice("BApp", tt.br.BApp, clone.BApp)
+
+			// Test Source
+			if tt.br.Source != nil {
+				if clone.Source == tt.br.Source {
+					t.Error("Clone() should create a new pointer for Source")
+				}
+				originalTID := tt.br.Source.TID
+				tt.br.Source.TID = "modified"
+				if clone.Source.TID != originalTID {
+					t.Error("Clone() should create deep copy of Source")
+				}
+			}
+
+			// Test Regs
+			if tt.br.Regs != nil {
+				if clone.Regs == tt.br.Regs {
+					t.Error("Clone() should create a new pointer for Regs")
+				}
+				originalCOPPA := tt.br.Regs.COPPA
+				tt.br.Regs.COPPA = 0
+				if clone.Regs.COPPA != originalCOPPA {
+					t.Error("Clone() should create deep copy of Regs")
+				}
+			}
+
+			// Test extension
+			if tt.br.Ext != nil {
+				orig := string(tt.br.Ext)
+				tt.br.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/brand_version.go
+++ b/openrtb2/brand_version.go
@@ -35,3 +35,20 @@ type BrandVersion struct {
 	//   Placeholder for advertising-system specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of BrandVersion
+func (b *BrandVersion) Clone() *BrandVersion {
+	if b == nil {
+		return nil
+	}
+
+	clone := *b
+
+	// Clone string slice
+	clone.Version = cloneStringSlice(b.Version)
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(b.Ext)
+
+	return &clone
+}

--- a/openrtb2/brand_version_test.go
+++ b/openrtb2/brand_version_test.go
@@ -1,0 +1,67 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBrandVersion_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		b    *BrandVersion
+	}{
+		{
+			name: "nil brand version",
+			b:    nil,
+		},
+		{
+			name: "empty brand version",
+			b:    &BrandVersion{},
+		},
+		{
+			name: "fully populated brand version",
+			b: &BrandVersion{
+				Brand:   "Chrome",
+				Version: []string{"91", "0", "4472", "77"},
+				Ext:     json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.b.Clone()
+
+			if tt.b == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil BrandVersion")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.Brand != tt.b.Brand {
+				t.Errorf("Clone() Brand = %v, want %v", clone.Brand, tt.b.Brand)
+			}
+
+			// Test slice
+			if len(tt.b.Version) > 0 {
+				original := tt.b.Version[0]
+				tt.b.Version[0] = "modified"
+				if clone.Version[0] != original {
+					t.Error("Clone() should create deep copy of Version slice")
+				}
+			}
+
+			// Test deep copy of extension
+			if tt.b.Ext != nil {
+				orig := string(tt.b.Ext)
+				tt.b.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/channel.go
+++ b/openrtb2/channel.go
@@ -47,3 +47,17 @@ type Channel struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Channel
+func (c *Channel) Clone() *Channel {
+	if c == nil {
+		return nil
+	}
+
+	clone := *c
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(c.Ext)
+
+	return &clone
+}

--- a/openrtb2/channel_test.go
+++ b/openrtb2/channel_test.go
@@ -1,0 +1,65 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChannel_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *Channel
+	}{
+		{
+			name: "nil channel",
+			c:    nil,
+		},
+		{
+			name: "empty channel",
+			c:    &Channel{},
+		},
+		{
+			name: "fully populated channel",
+			c: &Channel{
+				ID:     "ch1",
+				Name:   "Channel 1",
+				Domain: "channel1.com",
+				Ext:    json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.c.Clone()
+
+			if tt.c == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Channel")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.c.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.c.ID)
+			}
+			if clone.Name != tt.c.Name {
+				t.Errorf("Clone() Name = %v, want %v", clone.Name, tt.c.Name)
+			}
+			if clone.Domain != tt.c.Domain {
+				t.Errorf("Clone() Domain = %v, want %v", clone.Domain, tt.c.Domain)
+			}
+
+			// Test deep copy of extension
+			if tt.c.Ext != nil {
+				orig := string(tt.c.Ext)
+				tt.c.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/clone_helpers.go
+++ b/openrtb2/clone_helpers.go
@@ -1,0 +1,54 @@
+package openrtb2
+
+import "encoding/json"
+
+// cloneRawMessage creates a deep copy of a json.RawMessage
+func cloneRawMessage(m json.RawMessage) json.RawMessage {
+	if m == nil {
+		return nil
+	}
+	if len(m) == 0 {
+		return json.RawMessage{}
+	}
+	// Ensure we create a completely new slice with its own backing array
+	clone := make(json.RawMessage, len(m))
+	copy(clone, m)
+	return clone
+}
+
+// cloneInt8Ptr creates a deep copy of an *int8
+func cloneInt8Ptr(i *int8) *int8 {
+	if i == nil {
+		return nil
+	}
+	clone := *i
+	return &clone
+}
+
+// cloneInt64Ptr creates a deep copy of an *int64
+func cloneInt64Ptr(i *int64) *int64 {
+	if i == nil {
+		return nil
+	}
+	clone := *i
+	return &clone
+}
+
+// cloneFloat64Ptr creates a deep copy of a *float64
+func cloneFloat64Ptr(f *float64) *float64 {
+	if f == nil {
+		return nil
+	}
+	clone := *f
+	return &clone
+}
+
+// cloneStringSlice creates a deep copy of a string slice
+func cloneStringSlice(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	clone := make([]string, len(s))
+	copy(clone, s)
+	return clone
+}

--- a/openrtb2/clone_helpers_test.go
+++ b/openrtb2/clone_helpers_test.go
@@ -1,0 +1,236 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestCloneRawMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		m    json.RawMessage
+	}{
+		{
+			name: "nil message",
+			m:    nil,
+		},
+		{
+			name: "empty message",
+			m:    json.RawMessage{},
+		},
+		{
+			name: "valid message",
+			m:    json.RawMessage(`{"key": "value"}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := cloneRawMessage(tt.m)
+
+			// For nil input, expect nil output
+			if tt.m == nil {
+				if clone != nil {
+					t.Errorf("cloneRawMessage() = %v, want nil", clone)
+				}
+				return
+			}
+
+			// Verify initial equality
+			if !reflect.DeepEqual(clone, tt.m) {
+				t.Errorf("cloneRawMessage() = %v, want %v", clone, tt.m)
+			}
+
+			// Skip modification test for empty message
+			if len(tt.m) == 0 {
+				return
+			}
+
+			// Store original state and verify deep copy
+			orig := make(json.RawMessage, len(tt.m))
+			copy(orig, tt.m)
+			tt.m[0] = 'X'
+			if !reflect.DeepEqual(clone, orig) {
+				t.Errorf("clone was modified when original changed, clone = %v, want %v", clone, orig)
+			}
+		})
+	}
+}
+
+func TestCloneInt8Ptr(t *testing.T) {
+	var (
+		nilPtr *int8
+		val    int8 = 42
+	)
+
+	tests := []struct {
+		name string
+		i    *int8
+	}{
+		{
+			name: "nil pointer",
+			i:    nilPtr,
+		},
+		{
+			name: "valid pointer",
+			i:    &val,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := cloneInt8Ptr(tt.i)
+			if tt.i == nil {
+				if clone != nil {
+					t.Error("cloneInt8Ptr() should return nil for nil input")
+				}
+				return
+			}
+
+			if *clone != *tt.i {
+				t.Errorf("cloneInt8Ptr() = %v, want %v", *clone, *tt.i)
+			}
+
+			// Verify modification of original doesn't affect clone
+			orig := *tt.i
+			*tt.i = 99
+			if *clone != orig {
+				t.Error("clone should not be affected by modifications to original")
+			}
+		})
+	}
+}
+
+func TestCloneInt64Ptr(t *testing.T) {
+	var (
+		nilPtr *int64
+		val    int64 = 42
+	)
+
+	tests := []struct {
+		name string
+		i    *int64
+	}{
+		{
+			name: "nil pointer",
+			i:    nilPtr,
+		},
+		{
+			name: "valid pointer",
+			i:    &val,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := cloneInt64Ptr(tt.i)
+			if tt.i == nil {
+				if clone != nil {
+					t.Error("cloneInt64Ptr() should return nil for nil input")
+				}
+				return
+			}
+
+			if *clone != *tt.i {
+				t.Errorf("cloneInt64Ptr() = %v, want %v", *clone, *tt.i)
+			}
+
+			// Verify modification of original doesn't affect clone
+			orig := *tt.i
+			*tt.i = 99
+			if *clone != orig {
+				t.Error("clone should not be affected by modifications to original")
+			}
+		})
+	}
+}
+
+func TestCloneFloat64Ptr(t *testing.T) {
+	var (
+		nilPtr *float64
+		val    float64 = 42.5
+	)
+
+	tests := []struct {
+		name string
+		f    *float64
+	}{
+		{
+			name: "nil pointer",
+			f:    nilPtr,
+		},
+		{
+			name: "valid pointer",
+			f:    &val,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := cloneFloat64Ptr(tt.f)
+			if tt.f == nil {
+				if clone != nil {
+					t.Error("cloneFloat64Ptr() should return nil for nil input")
+				}
+				return
+			}
+
+			if *clone != *tt.f {
+				t.Errorf("cloneFloat64Ptr() = %v, want %v", *clone, *tt.f)
+			}
+
+			// Verify modification of original doesn't affect clone
+			orig := *tt.f
+			*tt.f = 99.9
+			if *clone != orig {
+				t.Error("clone should not be affected by modifications to original")
+			}
+		})
+	}
+}
+
+func TestCloneStringSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		s    []string
+	}{
+		{
+			name: "nil slice",
+			s:    nil,
+		},
+		{
+			name: "empty slice",
+			s:    []string{},
+		},
+		{
+			name: "slice with values",
+			s:    []string{"one", "two", "three"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := cloneStringSlice(tt.s)
+			if !reflect.DeepEqual(clone, tt.s) {
+				t.Errorf("cloneStringSlice() = %v, want %v", clone, tt.s)
+			}
+
+			if tt.s != nil {
+				// Store original state
+				orig := make([]string, len(tt.s))
+				copy(orig, tt.s)
+
+				// Modify original
+				if len(tt.s) > 0 {
+					tt.s[0] = "modified"
+				}
+
+				// Verify clone wasn't affected
+				if !reflect.DeepEqual(clone, orig) {
+					t.Error("clone should not be affected by modifications to original")
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/content.go
+++ b/openrtb2/content.go
@@ -283,3 +283,51 @@ type Content struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Content
+func (c *Content) Clone() *Content {
+	if c == nil {
+		return nil
+	}
+
+	clone := *c
+
+	// Clone pointer fields
+	clone.ProdQ = cloneProductionQualityPtr(c.ProdQ)
+	clone.VideoQuality = cloneProductionQualityPtr(c.VideoQuality)
+	clone.LiveStream = cloneInt8Ptr(c.LiveStream)
+	clone.SourceRelationship = cloneInt8Ptr(c.SourceRelationship)
+	clone.Embeddable = cloneInt8Ptr(c.Embeddable)
+
+	// Clone string slice fields
+	clone.Cat = cloneStringSlice(c.Cat)
+	clone.KwArray = cloneStringSlice(c.KwArray)
+
+	// Clone pointer objects
+	clone.Producer = c.Producer.Clone()
+
+	// Clone Data slice
+	if c.Data != nil {
+		clone.Data = make([]Data, len(c.Data))
+		for i := range c.Data {
+			clone.Data[i] = *c.Data[i].Clone()
+		}
+	}
+
+	// Clone Network and Channel
+	clone.Network = c.Network.Clone()
+	clone.Channel = c.Channel.Clone()
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(c.Ext)
+
+	return &clone
+}
+
+func cloneProductionQualityPtr(p *adcom1.ProductionQuality) *adcom1.ProductionQuality {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	return &clone
+}

--- a/openrtb2/content_test.go
+++ b/openrtb2/content_test.go
@@ -1,0 +1,152 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestContent_Clone(t *testing.T) {
+	var (
+		prodQ           = adcom1.ProductionQuality(1)
+		liveStream int8 = 1
+		sourceRel  int8 = 1
+		embeddable int8 = 1
+	)
+
+	tests := []struct {
+		name string
+		c    *Content
+	}{
+		{
+			name: "nil content",
+			c:    nil,
+		},
+		{
+			name: "empty content",
+			c:    &Content{},
+		},
+		{
+			name: "fully populated content",
+			c: &Content{
+				ID:                 "content1",
+				Episode:            1,
+				Title:              "Test Content",
+				Series:             "Test Series",
+				Season:             "Season 1",
+				Artist:             "Test Artist",
+				Genre:              "Test Genre",
+				Album:              "Test Album",
+				ISRC:               "TEST123",
+				Producer:           &Producer{ID: "prod1", Ext: json.RawMessage(`{"key": "value"}`)},
+				URL:                "http://test.com",
+				CatTax:             adcom1.CategoryTaxonomy(1),
+				Cat:                []string{"IAB1", "IAB2"},
+				ProdQ:              &prodQ,
+				VideoQuality:       &prodQ,
+				Context:            1,
+				ContentRating:      "PG",
+				UserRating:         "4.5",
+				QAGMediaRating:     1,
+				Keywords:           "test,content",
+				KwArray:            []string{"test", "content"},
+				LiveStream:         &liveStream,
+				SourceRelationship: &sourceRel,
+				Len:                300,
+				Language:           "en",
+				LangB:              "en-US",
+				Embeddable:         &embeddable,
+				Data: []Data{
+					{
+						ID:   "data1",
+						Name: "Data 1",
+						Segment: []Segment{
+							{ID: "seg1", Value: "val1"},
+						},
+						Ext: json.RawMessage(`{"key": "value"}`),
+					},
+				},
+				Network: &Network{
+					ID:   "net1",
+					Name: "Network 1",
+					Ext:  json.RawMessage(`{"key": "value"}`),
+				},
+				Channel: &Channel{
+					ID:   "ch1",
+					Name: "Channel 1",
+					Ext:  json.RawMessage(`{"key": "value"}`),
+				},
+				Ext: json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.c.Clone()
+
+			if tt.c == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Content")
+				}
+				return
+			}
+
+			// Test pointer fields
+			if tt.c.ProdQ != nil {
+				orig := *tt.c.ProdQ
+				*tt.c.ProdQ = adcom1.ProductionQuality(2)
+				if *clone.ProdQ != orig {
+					t.Error("Clone() should create deep copy of ProdQ")
+				}
+			}
+
+			// Test Producer
+			if tt.c.Producer != nil {
+				origID := tt.c.Producer.ID
+				tt.c.Producer.ID = "modified"
+				if clone.Producer.ID != origID {
+					t.Error("Clone() should create deep copy of Producer")
+				}
+			}
+
+			// Test Data slice
+			if len(tt.c.Data) > 0 {
+				origName := tt.c.Data[0].Name
+				tt.c.Data[0].Name = "modified"
+				if clone.Data[0].Name != origName {
+					t.Error("Clone() should create deep copy of Data")
+				}
+			}
+
+			// Test Network
+			if tt.c.Network != nil {
+				origID := tt.c.Network.ID
+				tt.c.Network.ID = "modified"
+				if clone.Network.ID != origID {
+					t.Error("Clone() should create deep copy of Network")
+				}
+			}
+
+			// Test Channel
+			if tt.c.Channel != nil {
+				origID := tt.c.Channel.ID
+				tt.c.Channel.ID = "modified"
+				if clone.Channel.ID != origID {
+					t.Error("Clone() should create deep copy of Channel")
+				}
+			}
+
+			// Test extension
+			if tt.c.Ext != nil {
+				orig := string(tt.c.Ext)
+				tt.c.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/data.go
+++ b/openrtb2/data.go
@@ -43,3 +43,25 @@ type Data struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Data
+func (d *Data) Clone() *Data {
+	if d == nil {
+		return nil
+	}
+
+	clone := *d
+
+	// Clone segments
+	if d.Segment != nil {
+		clone.Segment = make([]Segment, len(d.Segment))
+		for i := range d.Segment {
+			clone.Segment[i] = *d.Segment[i].Clone()
+		}
+	}
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(d.Ext)
+
+	return &clone
+}

--- a/openrtb2/data_test.go
+++ b/openrtb2/data_test.go
@@ -1,0 +1,94 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestData_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		d    *Data
+	}{
+		{
+			name: "nil data",
+			d:    nil,
+		},
+		{
+			name: "empty data",
+			d:    &Data{},
+		},
+		{
+			name: "fully populated data",
+			d: &Data{
+				ID:   "data1",
+				Name: "Data Provider 1",
+				Segment: []Segment{
+					{
+						ID:    "seg1",
+						Name:  "Segment 1",
+						Value: "value1",
+						Ext:   json.RawMessage(`{"key1": "value1"}`),
+					},
+					{
+						ID:    "seg2",
+						Name:  "Segment 2",
+						Value: "value2",
+						Ext:   json.RawMessage(`{"key2": "value2"}`),
+					},
+				},
+				Ext: json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.d.Clone()
+
+			if tt.d == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Data")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.d.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.d.ID)
+			}
+			if clone.Name != tt.d.Name {
+				t.Errorf("Clone() Name = %v, want %v", clone.Name, tt.d.Name)
+			}
+
+			// Test segments
+			if len(tt.d.Segment) > 0 {
+				origSegName := tt.d.Segment[0].Name
+				tt.d.Segment[0].Name = "modified"
+				if clone.Segment[0].Name != origSegName {
+					t.Error("Clone() should create deep copy of Segment slice")
+				}
+
+				// Test segment's extension
+				if tt.d.Segment[0].Ext != nil {
+					origSegExt := string(tt.d.Segment[0].Ext)
+					tt.d.Segment[0].Ext[0] = 'X'
+					clonedSegExt := string(clone.Segment[0].Ext)
+					if clonedSegExt != origSegExt {
+						t.Error("Clone() should create deep copy of Segment's Ext")
+					}
+				}
+			}
+
+			// Test deep copy of extension
+			if tt.d.Ext != nil {
+				orig := string(tt.d.Ext)
+				tt.d.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/deal.go
+++ b/openrtb2/deal.go
@@ -110,3 +110,29 @@ type Deal struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Deal
+func (d *Deal) Clone() *Deal {
+	if d == nil {
+		return nil
+	}
+
+	clone := *d
+
+	// Clone string slices
+	clone.WSeat = cloneStringSlice(d.WSeat)
+	clone.WADomain = cloneStringSlice(d.WADomain)
+
+	// Clone DurFloors slice
+	if d.DurFloors != nil {
+		clone.DurFloors = make([]DurFloors, len(d.DurFloors))
+		for i := range d.DurFloors {
+			clone.DurFloors[i] = *d.DurFloors[i].Clone()
+		}
+	}
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(d.Ext)
+
+	return &clone
+}

--- a/openrtb2/deal_test.go
+++ b/openrtb2/deal_test.go
@@ -1,0 +1,110 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDeal_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		d    *Deal
+	}{
+		{
+			name: "nil deal",
+			d:    nil,
+		},
+		{
+			name: "empty deal",
+			d:    &Deal{},
+		},
+		{
+			name: "fully populated deal",
+			d: &Deal{
+				ID:           "deal1",
+				BidFloor:     1.23,
+				BidFloorCur:  "USD",
+				AT:           1,
+				WSeat:        []string{"seat1", "seat2"},
+				WADomain:     []string{"domain1.com", "domain2.com"},
+				Guar:         1,
+				MinCPMPerSec: 0.5,
+				DurFloors: []DurFloors{
+					{
+						MinDur:   15,
+						BidFloor: 2.50,
+						Ext:      json.RawMessage(`{"key1": "value1"}`),
+					},
+					{
+						MinDur:   30,
+						MaxDur:   30,
+						BidFloor: 4.50,
+						Ext:      json.RawMessage(`{"key2": "value2"}`),
+					},
+				},
+				Ext: json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.d.Clone()
+
+			if tt.d == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Deal")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.d.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.d.ID)
+			}
+			if clone.BidFloor != tt.d.BidFloor {
+				t.Errorf("Clone() BidFloor = %v, want %v", clone.BidFloor, tt.d.BidFloor)
+			}
+			if clone.MinCPMPerSec != tt.d.MinCPMPerSec {
+				t.Errorf("Clone() MinCPMPerSec = %v, want %v", clone.MinCPMPerSec, tt.d.MinCPMPerSec)
+			}
+
+			// Test string slices
+			if len(tt.d.WSeat) > 0 {
+				original := tt.d.WSeat[0]
+				tt.d.WSeat[0] = "modified"
+				if clone.WSeat[0] != original {
+					t.Error("Clone() should create deep copy of WSeat slice")
+				}
+			}
+
+			// Test DurFloors
+			if len(tt.d.DurFloors) > 0 {
+				original := tt.d.DurFloors[0].BidFloor
+				tt.d.DurFloors[0].BidFloor = 999.99
+				if clone.DurFloors[0].BidFloor != original {
+					t.Error("Clone() should create deep copy of DurFloors")
+				}
+
+				if tt.d.DurFloors[0].Ext != nil {
+					origExt := string(tt.d.DurFloors[0].Ext)
+					tt.d.DurFloors[0].Ext[0] = 'X'
+					clonedExt := string(clone.DurFloors[0].Ext)
+					if clonedExt != origExt {
+						t.Error("Clone() should create deep copy of DurFloors[0].Ext")
+					}
+				}
+			}
+
+			// Test extension
+			if tt.d.Ext != nil {
+				orig := string(tt.d.Ext)
+				tt.d.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/device.go
+++ b/openrtb2/device.go
@@ -324,3 +324,36 @@ type Device struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Device
+func (d *Device) Clone() *Device {
+	if d == nil {
+		return nil
+	}
+
+	clone := *d
+
+	// Clone pointer fields
+	clone.DNT = cloneInt8Ptr(d.DNT)
+	clone.Lmt = cloneInt8Ptr(d.Lmt)
+	clone.JS = cloneInt8Ptr(d.JS)
+	clone.GeoFetch = cloneInt8Ptr(d.GeoFetch)
+	clone.ConnectionType = cloneConnectionTypePtr(d.ConnectionType)
+
+	// Clone pointer objects
+	clone.Geo = d.Geo.Clone()
+	clone.SUA = d.SUA.Clone()
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(d.Ext)
+
+	return &clone
+}
+
+func cloneConnectionTypePtr(c *adcom1.ConnectionType) *adcom1.ConnectionType {
+	if c == nil {
+		return nil
+	}
+	clone := *c
+	return &clone
+}

--- a/openrtb2/device_test.go
+++ b/openrtb2/device_test.go
@@ -1,0 +1,158 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestDevice_Clone(t *testing.T) {
+	var (
+		lat            float64               = 40.7128
+		lon            float64               = -74.0060
+		dnt            int8                  = 1
+		lmt            int8                  = 1
+		js             int8                  = 1
+		geoFetch       int8                  = 1
+		mobile         int8                  = 1
+		connectionType adcom1.ConnectionType = 2
+	)
+
+	tests := []struct {
+		name string
+		d    *Device
+	}{
+		{
+			name: "nil device",
+			d:    nil,
+		},
+		{
+			name: "empty device",
+			d:    &Device{},
+		},
+		{
+			name: "fully populated device",
+			d: &Device{
+				Geo: &Geo{
+					Lat:  &lat,
+					Lon:  &lon,
+					Type: adcom1.LocationType(1),
+					Ext:  json.RawMessage(`{"key": "value"}`),
+				},
+				DNT: &dnt,
+				Lmt: &lmt,
+				UA:  "Mozilla/5.0",
+				SUA: &UserAgent{
+					Browsers: []BrandVersion{
+						{
+							Brand:   "Chrome",
+							Version: []string{"91"},
+							Ext:     json.RawMessage(`{"key": "value"}`),
+						},
+					},
+					Mobile: &mobile,
+					Ext:    json.RawMessage(`{"key": "value"}`),
+				},
+				IP:             "192.168.1.1",
+				IPv6:           "2001:db8::1",
+				DeviceType:     1,
+				Make:           "Apple",
+				Model:          "iPhone",
+				OS:             "iOS",
+				OSV:            "14.0",
+				HWV:            "iPhone12,1",
+				H:              1920,
+				W:              1080,
+				PPI:            458,
+				PxRatio:        2.0,
+				JS:             &js,
+				GeoFetch:       &geoFetch,
+				FlashVer:       "1.0",
+				Language:       "en",
+				Carrier:        "Verizon",
+				MCCMNC:         "310-012",
+				ConnectionType: &connectionType,
+				IFA:            "AAAAAA-BBBB-CCCC-1111",
+				Ext:            json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.d.Clone()
+
+			if tt.d == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Device")
+				}
+				return
+			}
+
+			// Test pointer fields
+			if tt.d.DNT != nil {
+				orig := *tt.d.DNT
+				*tt.d.DNT = 0
+				if *clone.DNT != orig {
+					t.Error("Clone() should create deep copy of DNT")
+				}
+			}
+
+			// Test Geo
+			if tt.d.Geo != nil {
+				origLat := *tt.d.Geo.Lat
+				*tt.d.Geo.Lat = 999.999
+				if *clone.Geo.Lat != origLat {
+					t.Error("Clone() should create deep copy of Geo.Lat")
+				}
+
+				// Test Geo's extension
+				if tt.d.Geo.Ext != nil {
+					origGeoExt := string(tt.d.Geo.Ext)
+					tt.d.Geo.Ext[0] = 'X'
+					clonedGeoExt := string(clone.Geo.Ext)
+					if clonedGeoExt != origGeoExt {
+						t.Error("Clone() should create deep copy of Geo.Ext")
+					}
+				}
+			}
+
+			// Test UserAgent
+			if tt.d.SUA != nil && len(tt.d.SUA.Browsers) > 0 {
+				origBrand := tt.d.SUA.Browsers[0].Brand
+				tt.d.SUA.Browsers[0].Brand = "modified"
+				if clone.SUA.Browsers[0].Brand != origBrand {
+					t.Error("Clone() should create deep copy of SUA.Browsers")
+				}
+
+				if tt.d.SUA.Mobile != nil {
+					origMobile := *tt.d.SUA.Mobile
+					*tt.d.SUA.Mobile = 0
+					if *clone.SUA.Mobile != origMobile {
+						t.Error("Clone() should create deep copy of SUA.Mobile")
+					}
+				}
+			}
+
+			// Test ConnectionType
+			if tt.d.ConnectionType != nil {
+				origConnType := *tt.d.ConnectionType
+				*tt.d.ConnectionType = adcom1.ConnectionType(3)
+				if *clone.ConnectionType != origConnType {
+					t.Error("Clone() should create deep copy of ConnectionType")
+				}
+			}
+
+			// Test extension
+			if tt.d.Ext != nil {
+				orig := string(tt.d.Ext)
+				tt.d.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/dooh.go
+++ b/openrtb2/dooh.go
@@ -87,3 +87,41 @@ type DOOH struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the DOOH object.
+func (d *DOOH) Clone() *DOOH {
+	if d == nil {
+		return nil
+	}
+	clone := *d
+
+	// Deep copy venue type slice
+	if d.VenueType != nil {
+		clone.VenueType = make([]string, len(d.VenueType))
+		copy(clone.VenueType, d.VenueType)
+	}
+
+	// Deep copy venue type taxonomy
+	if d.VenueTypeTax != nil {
+		tax := *d.VenueTypeTax
+		clone.VenueTypeTax = &tax
+	}
+
+	// Deep copy publisher
+	if d.Publisher != nil {
+		clone.Publisher = d.Publisher.Clone()
+	}
+
+	// Deep copy content
+	if d.Content != nil {
+		clone.Content = d.Content.Clone()
+	}
+
+	// Deep copy ext
+	if d.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(d.Ext))
+		copy(clone.Ext, d.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/dooh_test.go
+++ b/openrtb2/dooh_test.go
@@ -1,0 +1,132 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestDOOH_Clone(t *testing.T) {
+	venueTypeTax := adcom1.VenueTaxonomyOpenOOH10
+
+	tests := []struct {
+		name string
+		d    *DOOH
+	}{
+		{
+			name: "nil dooh",
+			d:    nil,
+		},
+		{
+			name: "empty dooh",
+			d:    &DOOH{},
+		},
+		{
+			name: "fully populated dooh",
+			d: &DOOH{
+				ID:           "dooh123",
+				Name:         "Times Square Display",
+				VenueType:    []string{"street", "billboard"},
+				VenueTypeTax: &venueTypeTax,
+				Publisher: &Publisher{
+					ID:     "pub123",
+					Name:   "DOOH Media Corp",
+					Domain: "doohmedia.com",
+					Ext:    json.RawMessage(`{"publisher_key": "value"}`),
+				},
+				Domain:   "display1.doohmedia.com",
+				Keywords: "times square,billboard,nyc",
+				Content: &Content{
+					ID:    "content123",
+					Title: "Times Square Feed",
+					Ext:   json.RawMessage(`{"content_key": "value"}`),
+				},
+				Ext: json.RawMessage(`{"dooh_key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.d.Clone()
+
+			if tt.d == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil DOOH")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.d.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.d.ID)
+			}
+			if clone.Name != tt.d.Name {
+				t.Errorf("Clone() Name = %v, want %v", clone.Name, tt.d.Name)
+			}
+			if clone.Domain != tt.d.Domain {
+				t.Errorf("Clone() Domain = %v, want %v", clone.Domain, tt.d.Domain)
+			}
+			if clone.Keywords != tt.d.Keywords {
+				t.Errorf("Clone() Keywords = %v, want %v", clone.Keywords, tt.d.Keywords)
+			}
+
+			// Test VenueType slice
+			if len(tt.d.VenueType) > 0 {
+				if len(clone.VenueType) != len(tt.d.VenueType) {
+					t.Errorf("Clone() VenueType length = %v, want %v", len(clone.VenueType), len(tt.d.VenueType))
+				}
+				original := tt.d.VenueType[0]
+				tt.d.VenueType[0] = "modified"
+				if clone.VenueType[0] != original {
+					t.Error("Clone() should create deep copy of VenueType")
+				}
+			}
+
+			// Test VenueTypeTax
+			if tt.d.VenueTypeTax != nil {
+				if clone.VenueTypeTax == tt.d.VenueTypeTax {
+					t.Error("Clone() should create a new pointer for VenueTypeTax")
+				}
+				if *clone.VenueTypeTax != *tt.d.VenueTypeTax {
+					t.Error("Clone() VenueTypeTax value should match original")
+				}
+			}
+
+			// Test Publisher
+			if tt.d.Publisher != nil {
+				if clone.Publisher == tt.d.Publisher {
+					t.Error("Clone() should create a new pointer for Publisher")
+				}
+				origPubID := tt.d.Publisher.ID
+				tt.d.Publisher.ID = "modified"
+				if clone.Publisher.ID != origPubID {
+					t.Error("Clone() should create deep copy of Publisher")
+				}
+			}
+
+			// Test Content
+			if tt.d.Content != nil {
+				if clone.Content == tt.d.Content {
+					t.Error("Clone() should create a new pointer for Content")
+				}
+				origContentID := tt.d.Content.ID
+				tt.d.Content.ID = "modified"
+				if clone.Content.ID != origContentID {
+					t.Error("Clone() should create deep copy of Content")
+				}
+			}
+
+			// Test extension
+			if tt.d.Ext != nil {
+				orig := string(tt.d.Ext)
+				tt.d.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/durfloors.go
+++ b/openrtb2/durfloors.go
@@ -51,3 +51,13 @@ type DurFloors struct {
 	//   Placeholder for vendor specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of DurFloors
+func (d *DurFloors) Clone() *DurFloors {
+	if d == nil {
+		return nil
+	}
+	clone := *d
+	clone.Ext = cloneRawMessage(d.Ext)
+	return &clone
+}

--- a/openrtb2/durfloors_test.go
+++ b/openrtb2/durfloors_test.go
@@ -1,0 +1,66 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDurFloors_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		d    *DurFloors
+	}{
+		{
+			name: "nil durfloors",
+			d:    nil,
+		},
+		{
+			name: "empty durfloors",
+			d:    &DurFloors{},
+		},
+		{
+			name: "fully populated durfloors",
+			d: &DurFloors{
+				MinDur:   15,
+				MaxDur:   30,
+				BidFloor: 10.5,
+				Ext:      json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.d.Clone()
+
+			if tt.d == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil DurFloors")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.MinDur != tt.d.MinDur {
+				t.Errorf("Clone() MinDur = %v, want %v", clone.MinDur, tt.d.MinDur)
+			}
+			if clone.MaxDur != tt.d.MaxDur {
+				t.Errorf("Clone() MaxDur = %v, want %v", clone.MaxDur, tt.d.MaxDur)
+			}
+			if clone.BidFloor != tt.d.BidFloor {
+				t.Errorf("Clone() BidFloor = %v, want %v", clone.BidFloor, tt.d.BidFloor)
+			}
+
+			// Test deep copy of extension
+			if tt.d.Ext != nil {
+				orig := string(tt.d.Ext)       // Store original as string
+				tt.d.Ext[0] = 'X'              // Modify original
+				clonedStr := string(clone.Ext) // Get clone as string
+
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot:  %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/eid.go
+++ b/openrtb2/eid.go
@@ -35,3 +35,28 @@ type EID struct {
 	//   Placeholder for advertising-system specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the EID object.
+func (e *EID) Clone() *EID {
+	if e == nil {
+		return nil
+	}
+
+	clone := *e
+
+	// Deep copy UIDs
+	if e.UIDs != nil {
+		clone.UIDs = make([]UID, len(e.UIDs))
+		for i := range e.UIDs {
+			clone.UIDs[i] = *e.UIDs[i].Clone()
+		}
+	}
+
+	// Deep copy ext
+	if e.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(e.Ext))
+		copy(clone.Ext, e.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/eid_test.go
+++ b/openrtb2/eid_test.go
@@ -1,0 +1,94 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestEID_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		e    *EID
+	}{
+		{
+			name: "nil eid",
+			e:    nil,
+		},
+		{
+			name: "empty eid",
+			e:    &EID{},
+		},
+		{
+			name: "fully populated eid",
+			e: &EID{
+				Source: "example.com",
+				UIDs: []UID{
+					{
+						ID:    "uid1",
+						AType: adcom1.AgentTypeWeb,
+						Ext:   json.RawMessage(`{"uid_key":"value1"}`),
+					},
+					{
+						ID:    "uid2",
+						AType: adcom1.AgentTypeApp,
+						Ext:   json.RawMessage(`{"uid_key":"value2"}`),
+					},
+				},
+				Ext: json.RawMessage(`{"eid_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.e.Clone()
+
+			if tt.e == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil EID")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.Source != tt.e.Source {
+				t.Errorf("Clone() Source = %v, want %v", clone.Source, tt.e.Source)
+			}
+
+			// Test UIDs array
+			if len(tt.e.UIDs) > 0 {
+				if len(clone.UIDs) != len(tt.e.UIDs) {
+					t.Errorf("Clone() UIDs length = %v, want %v", len(clone.UIDs), len(tt.e.UIDs))
+				}
+
+				// Test deep copy of first UID
+				originalID := tt.e.UIDs[0].ID
+				tt.e.UIDs[0].ID = "modified"
+				if clone.UIDs[0].ID != originalID {
+					t.Error("Clone() should create deep copy of UIDs")
+				}
+
+				if tt.e.UIDs[0].Ext != nil {
+					orig := string(tt.e.UIDs[0].Ext)
+					tt.e.UIDs[0].Ext[0] = 'X'
+					clonedStr := string(clone.UIDs[0].Ext)
+					if clonedStr != orig {
+						t.Error("Clone() should create deep copy of UIDs[0].Ext")
+					}
+				}
+			}
+
+			// Test extension
+			if tt.e.Ext != nil {
+				orig := string(tt.e.Ext)
+				tt.e.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/format.go
+++ b/openrtb2/format.go
@@ -58,3 +58,15 @@ type Format struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Format
+func (f *Format) Clone() *Format {
+	if f == nil {
+		return nil
+	}
+
+	clone := *f
+	clone.Ext = cloneRawMessage(f.Ext)
+
+	return &clone
+}

--- a/openrtb2/format_test.go
+++ b/openrtb2/format_test.go
@@ -1,0 +1,69 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestFormat_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		f    *Format
+	}{
+		{
+			name: "nil format",
+			f:    nil,
+		},
+		{
+			name: "empty format",
+			f:    &Format{},
+		},
+		{
+			name: "complete format",
+			f: &Format{
+				W:      300,
+				H:      250,
+				WRatio: 16,
+				HRatio: 9,
+				WMin:   100,
+				Ext:    json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.f.Clone()
+
+			if tt.f == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Format")
+				}
+				return
+			}
+
+			// Verify initial equality
+			if !reflect.DeepEqual(clone, tt.f) {
+				t.Errorf("Clone() = %v, want %v", clone, tt.f)
+			}
+
+			// Verify deep copy by modifying the original
+			if tt.f.Ext != nil {
+				orig := make(json.RawMessage, len(tt.f.Ext))
+				copy(orig, tt.f.Ext)
+				tt.f.Ext[0] = 'X'
+				if !reflect.DeepEqual(clone.Ext, orig) {
+					t.Error("Clone() should create a deep copy of Ext")
+				}
+			}
+
+			// Modify primitive fields
+			origW := tt.f.W
+			tt.f.W = 999
+			if clone.W != origW {
+				t.Error("Clone() should create a deep copy of primitive fields")
+			}
+		})
+	}
+}

--- a/openrtb2/geo.go
+++ b/openrtb2/geo.go
@@ -142,3 +142,21 @@ type Geo struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Geo
+func (g *Geo) Clone() *Geo {
+	if g == nil {
+		return nil
+	}
+
+	clone := *g
+
+	// Clone float64 pointers
+	clone.Lat = cloneFloat64Ptr(g.Lat)
+	clone.Lon = cloneFloat64Ptr(g.Lon)
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(g.Ext)
+
+	return &clone
+}

--- a/openrtb2/imp.go
+++ b/openrtb2/imp.go
@@ -235,3 +235,81 @@ type Imp struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the Imp object.
+func (i *Imp) Clone() *Imp {
+	if i == nil {
+		return nil
+	}
+
+	clone := *i
+
+	// Deep copy Metric slice
+	if i.Metric != nil {
+		clone.Metric = make([]Metric, len(i.Metric))
+		for j := range i.Metric {
+			clone.Metric[j] = *i.Metric[j].Clone()
+		}
+	}
+
+	// Deep copy Banner
+	if i.Banner != nil {
+		clone.Banner = i.Banner.Clone()
+	}
+
+	// Deep copy Video
+	if i.Video != nil {
+		clone.Video = i.Video.Clone()
+	}
+
+	// Deep copy Audio
+	if i.Audio != nil {
+		clone.Audio = i.Audio.Clone()
+	}
+
+	// Deep copy Native
+	if i.Native != nil {
+		clone.Native = i.Native.Clone()
+	}
+
+	// Deep copy PMP
+	if i.PMP != nil {
+		clone.PMP = i.PMP.Clone()
+	}
+
+	// Deep copy ClickBrowser
+	if i.ClickBrowser != nil {
+		cb := *i.ClickBrowser
+		clone.ClickBrowser = &cb
+	}
+
+	// Deep copy Secure
+	if i.Secure != nil {
+		s := *i.Secure
+		clone.Secure = &s
+	}
+
+	// Deep copy IframeBuster slice
+	if i.IframeBuster != nil {
+		clone.IframeBuster = make([]string, len(i.IframeBuster))
+		copy(clone.IframeBuster, i.IframeBuster)
+	}
+
+	// Deep copy Qty
+	if i.Qty != nil {
+		clone.Qty = i.Qty.Clone()
+	}
+
+	// Deep copy Refresh
+	if i.Refresh != nil {
+		clone.Refresh = i.Refresh.Clone()
+	}
+
+	// Deep copy ext
+	if i.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(i.Ext))
+		copy(clone.Ext, i.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/imp_test.go
+++ b/openrtb2/imp_test.go
@@ -1,0 +1,296 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestImp_Clone(t *testing.T) {
+	clickBrowser := int8(1)
+	secure := int8(1)
+	count := 2
+
+	tests := []struct {
+		name string
+		i    *Imp
+	}{
+		{
+			name: "nil imp",
+			i:    nil,
+		},
+		{
+			name: "empty imp",
+			i:    &Imp{},
+		},
+		{
+			name: "fully populated imp",
+			i: &Imp{
+				ID: "imp1",
+				Metric: []Metric{
+					{
+						Type:   "viewability",
+						Value:  0.85,
+						Vendor: "vendor1",
+						Ext:    json.RawMessage(`{"metric_key":"value"}`),
+					},
+				},
+				Banner: &Banner{
+					Format: []Format{
+						{W: 300, H: 250, WRatio: 1, HRatio: 1},
+					},
+					Ext: json.RawMessage(`{"banner_key":"value"}`),
+				},
+				Video: &Video{
+					MIMEs: []string{"video/mp4"},
+					Ext:   json.RawMessage(`{"video_key":"value"}`),
+				},
+				Audio: &Audio{
+					MIMEs: []string{"audio/mp3"},
+					Ext:   json.RawMessage(`{"audio_key":"value"}`),
+				},
+				Native: &Native{
+					Request: "native request string",
+					Ext:     json.RawMessage(`{"native_key":"value"}`),
+				},
+				PMP: &PMP{
+					PrivateAuction: 1,
+					Deals: []Deal{
+						{
+							ID:          "deal1",
+							BidFloor:    1.23,
+							BidFloorCur: "USD",
+							Ext:         json.RawMessage(`{"deal_key":"value"}`),
+						},
+					},
+					Ext: json.RawMessage(`{"pmp_key":"value"}`),
+				},
+				DisplayManager:    "dm1",
+				DisplayManagerVer: "1.0",
+				Instl:             1,
+				TagID:             "tag1",
+				BidFloor:          1.23,
+				BidFloorCur:       "USD",
+				ClickBrowser:      &clickBrowser,
+				Secure:            &secure,
+				IframeBuster:      []string{"buster1", "buster2"},
+				Rwdd:              1,
+				Exp:               30,
+				Qty: &Qty{
+					Multiplier: 14.2,
+					Vendor:     "example.com",
+					Ext:        json.RawMessage(`{"qty_key":"value"}`),
+				},
+				DT: 1621234567890,
+				Refresh: &Refresh{
+					RefSettings: []RefSettings{
+						{
+							RefType: 1,
+							MinInt:  30,
+							Ext:     json.RawMessage(`{"refsettings_key":"value"}`),
+						},
+					},
+					Count: &count,
+					Ext:   json.RawMessage(`{"refresh_key":"value"}`),
+				},
+				Ext: json.RawMessage(`{"imp_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.i.Clone()
+
+			if tt.i == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Imp")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.i.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.i.ID)
+			}
+			if clone.DisplayManager != tt.i.DisplayManager {
+				t.Errorf("Clone() DisplayManager = %v, want %v", clone.DisplayManager, tt.i.DisplayManager)
+			}
+			if clone.DisplayManagerVer != tt.i.DisplayManagerVer {
+				t.Errorf("Clone() DisplayManagerVer = %v, want %v", clone.DisplayManagerVer, tt.i.DisplayManagerVer)
+			}
+			if clone.Instl != tt.i.Instl {
+				t.Errorf("Clone() Instl = %v, want %v", clone.Instl, tt.i.Instl)
+			}
+			if clone.TagID != tt.i.TagID {
+				t.Errorf("Clone() TagID = %v, want %v", clone.TagID, tt.i.TagID)
+			}
+			if clone.BidFloor != tt.i.BidFloor {
+				t.Errorf("Clone() BidFloor = %v, want %v", clone.BidFloor, tt.i.BidFloor)
+			}
+			if clone.BidFloorCur != tt.i.BidFloorCur {
+				t.Errorf("Clone() BidFloorCur = %v, want %v", clone.BidFloorCur, tt.i.BidFloorCur)
+			}
+			if clone.Rwdd != tt.i.Rwdd {
+				t.Errorf("Clone() Rwdd = %v, want %v", clone.Rwdd, tt.i.Rwdd)
+			}
+			if clone.Exp != tt.i.Exp {
+				t.Errorf("Clone() Exp = %v, want %v", clone.Exp, tt.i.Exp)
+			}
+			if clone.DT != tt.i.DT {
+				t.Errorf("Clone() DT = %v, want %v", clone.DT, tt.i.DT)
+			}
+
+			// Test Metric slice
+			if len(tt.i.Metric) > 0 {
+				if len(clone.Metric) != len(tt.i.Metric) {
+					t.Errorf("Clone() Metric length = %v, want %v", len(clone.Metric), len(tt.i.Metric))
+				}
+				original := tt.i.Metric[0].Type
+				tt.i.Metric[0].Type = "modified"
+				if clone.Metric[0].Type != original {
+					t.Error("Clone() should create deep copy of Metric")
+				}
+			}
+
+			// Test Banner
+			if tt.i.Banner != nil {
+				if clone.Banner == tt.i.Banner {
+					t.Error("Clone() should create a new pointer for Banner")
+				}
+				if len(tt.i.Banner.Format) > 0 {
+					original := tt.i.Banner.Format[0].W
+					tt.i.Banner.Format[0].W = 999
+					if clone.Banner.Format[0].W != original {
+						t.Error("Clone() should create deep copy of Banner.Format")
+					}
+				}
+			}
+
+			// Test Video
+			if tt.i.Video != nil {
+				if clone.Video == tt.i.Video {
+					t.Error("Clone() should create a new pointer for Video")
+				}
+				if len(tt.i.Video.MIMEs) > 0 {
+					original := tt.i.Video.MIMEs[0]
+					tt.i.Video.MIMEs[0] = "modified"
+					if clone.Video.MIMEs[0] != original {
+						t.Error("Clone() should create deep copy of Video.MIMEs")
+					}
+				}
+			}
+
+			// Test Audio
+			if tt.i.Audio != nil {
+				if clone.Audio == tt.i.Audio {
+					t.Error("Clone() should create a new pointer for Audio")
+				}
+				if len(tt.i.Audio.MIMEs) > 0 {
+					original := tt.i.Audio.MIMEs[0]
+					tt.i.Audio.MIMEs[0] = "modified"
+					if clone.Audio.MIMEs[0] != original {
+						t.Error("Clone() should create deep copy of Audio.MIMEs")
+					}
+				}
+			}
+
+			// Test Native
+			if tt.i.Native != nil {
+				if clone.Native == tt.i.Native {
+					t.Error("Clone() should create a new pointer for Native")
+				}
+				original := tt.i.Native.Request
+				tt.i.Native.Request = "modified"
+				if clone.Native.Request != original {
+					t.Error("Clone() should create deep copy of Native fields")
+				}
+			}
+
+			// Test PMP
+			if tt.i.PMP != nil {
+				if clone.PMP == tt.i.PMP {
+					t.Error("Clone() should create a new pointer for PMP")
+				}
+				if len(tt.i.PMP.Deals) > 0 {
+					original := tt.i.PMP.Deals[0].ID
+					tt.i.PMP.Deals[0].ID = "modified"
+					if clone.PMP.Deals[0].ID != original {
+						t.Error("Clone() should create deep copy of PMP.Deals")
+					}
+				}
+			}
+
+			// Test ClickBrowser pointer
+			if tt.i.ClickBrowser != nil {
+				if *clone.ClickBrowser != *tt.i.ClickBrowser {
+					t.Errorf("Clone() ClickBrowser = %v, want %v", *clone.ClickBrowser, *tt.i.ClickBrowser)
+				}
+				oldCB := *tt.i.ClickBrowser
+				*tt.i.ClickBrowser = 0
+				if *clone.ClickBrowser != oldCB {
+					t.Error("Clone() should create deep copy of ClickBrowser")
+				}
+			}
+
+			// Test Secure pointer
+			if tt.i.Secure != nil {
+				if *clone.Secure != *tt.i.Secure {
+					t.Errorf("Clone() Secure = %v, want %v", *clone.Secure, *tt.i.Secure)
+				}
+				oldSecure := *tt.i.Secure
+				*tt.i.Secure = 0
+				if *clone.Secure != oldSecure {
+					t.Error("Clone() should create deep copy of Secure")
+				}
+			}
+
+			// Test IframeBuster slice
+			if len(tt.i.IframeBuster) > 0 {
+				if len(clone.IframeBuster) != len(tt.i.IframeBuster) {
+					t.Errorf("Clone() IframeBuster length = %v, want %v", len(clone.IframeBuster), len(tt.i.IframeBuster))
+				}
+				original := tt.i.IframeBuster[0]
+				tt.i.IframeBuster[0] = "modified"
+				if clone.IframeBuster[0] != original {
+					t.Error("Clone() should create deep copy of IframeBuster")
+				}
+			}
+
+			// Test Qty
+			if tt.i.Qty != nil {
+				if clone.Qty == tt.i.Qty {
+					t.Error("Clone() should create a new pointer for Qty")
+				}
+				original := tt.i.Qty.Multiplier
+				tt.i.Qty.Multiplier = 999.99
+				if clone.Qty.Multiplier != original {
+					t.Error("Clone() should create deep copy of Qty")
+				}
+			}
+
+			// Test Refresh
+			if tt.i.Refresh != nil {
+				if clone.Refresh == tt.i.Refresh {
+					t.Error("Clone() should create a new pointer for Refresh")
+				}
+				if tt.i.Refresh.Count != nil {
+					original := *tt.i.Refresh.Count
+					*tt.i.Refresh.Count = 999
+					if *clone.Refresh.Count != original {
+						t.Error("Clone() should create deep copy of Refresh.Count")
+					}
+				}
+			}
+
+			// Test extension
+			if tt.i.Ext != nil {
+				orig := string(tt.i.Ext)
+				tt.i.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/metric.go
+++ b/openrtb2/metric.go
@@ -46,3 +46,17 @@ type Metric struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Metric
+func (m *Metric) Clone() *Metric {
+	if m == nil {
+		return nil
+	}
+
+	clone := *m
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(m.Ext)
+
+	return &clone
+}

--- a/openrtb2/metric_test.go
+++ b/openrtb2/metric_test.go
@@ -1,0 +1,65 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMetric_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		m    *Metric
+	}{
+		{
+			name: "nil metric",
+			m:    nil,
+		},
+		{
+			name: "empty metric",
+			m:    &Metric{},
+		},
+		{
+			name: "fully populated metric",
+			m: &Metric{
+				Type:   "viewability",
+				Value:  0.85,
+				Vendor: "EXCHANGE",
+				Ext:    json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.m.Clone()
+
+			if tt.m == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Metric")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.Type != tt.m.Type {
+				t.Errorf("Clone() Type = %v, want %v", clone.Type, tt.m.Type)
+			}
+			if clone.Value != tt.m.Value {
+				t.Errorf("Clone() Value = %v, want %v", clone.Value, tt.m.Value)
+			}
+			if clone.Vendor != tt.m.Vendor {
+				t.Errorf("Clone() Vendor = %v, want %v", clone.Vendor, tt.m.Vendor)
+			}
+
+			// Test deep copy of extension
+			if tt.m.Ext != nil {
+				orig := string(tt.m.Ext)
+				tt.m.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/native.go
+++ b/openrtb2/native.go
@@ -81,3 +81,28 @@ type Native struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Native
+func (n *Native) Clone() *Native {
+	if n == nil {
+		return nil
+	}
+
+	clone := *n
+
+	// Clone slices
+	if n.API != nil {
+		clone.API = make([]adcom1.APIFramework, len(n.API))
+		copy(clone.API, n.API)
+	}
+
+	if n.BAttr != nil {
+		clone.BAttr = make([]adcom1.CreativeAttribute, len(n.BAttr))
+		copy(clone.BAttr, n.BAttr)
+	}
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(n.Ext)
+
+	return &clone
+}

--- a/openrtb2/native_test.go
+++ b/openrtb2/native_test.go
@@ -1,0 +1,82 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestNative_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		n    *Native
+	}{
+		{
+			name: "nil native",
+			n:    nil,
+		},
+		{
+			name: "empty native",
+			n:    &Native{},
+		},
+		{
+			name: "fully populated native",
+			n: &Native{
+				Request: `{"native":{"layout":1,"assets":[{"id":1,"title":{"len":25}}]}}`,
+				Ver:     "1.2",
+				API:     []adcom1.APIFramework{1, 2},
+				BAttr:   []adcom1.CreativeAttribute{1, 2},
+				Ext:     json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.n.Clone()
+
+			if tt.n == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Native")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if tt.n.Request != clone.Request {
+				t.Errorf("Clone() Request = %v, want %v", clone.Request, tt.n.Request)
+			}
+			if tt.n.Ver != clone.Ver {
+				t.Errorf("Clone() Ver = %v, want %v", clone.Ver, tt.n.Ver)
+			}
+
+			// Test slices
+			if len(tt.n.API) > 0 {
+				original := tt.n.API[0]
+				tt.n.API[0] = 999
+				if clone.API[0] != original {
+					t.Error("Clone() should create deep copy of API slice")
+				}
+			}
+
+			if len(tt.n.BAttr) > 0 {
+				original := tt.n.BAttr[0]
+				tt.n.BAttr[0] = 999
+				if clone.BAttr[0] != original {
+					t.Error("Clone() should create deep copy of BAttr slice")
+				}
+			}
+
+			// Test deep copy of extension
+			if tt.n.Ext != nil {
+				orig := string(tt.n.Ext)
+				tt.n.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/network.go
+++ b/openrtb2/network.go
@@ -47,3 +47,17 @@ type Network struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Network
+func (n *Network) Clone() *Network {
+	if n == nil {
+		return nil
+	}
+
+	clone := *n
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(n.Ext)
+
+	return &clone
+}

--- a/openrtb2/network_test.go
+++ b/openrtb2/network_test.go
@@ -1,0 +1,65 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNetwork_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		n    *Network
+	}{
+		{
+			name: "nil network",
+			n:    nil,
+		},
+		{
+			name: "empty network",
+			n:    &Network{},
+		},
+		{
+			name: "fully populated network",
+			n: &Network{
+				ID:     "net1",
+				Name:   "Network 1",
+				Domain: "network1.com",
+				Ext:    json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.n.Clone()
+
+			if tt.n == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Network")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.n.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.n.ID)
+			}
+			if clone.Name != tt.n.Name {
+				t.Errorf("Clone() Name = %v, want %v", clone.Name, tt.n.Name)
+			}
+			if clone.Domain != tt.n.Domain {
+				t.Errorf("Clone() Domain = %v, want %v", clone.Domain, tt.n.Domain)
+			}
+
+			// Test deep copy of extension
+			if tt.n.Ext != nil {
+				orig := string(tt.n.Ext)
+				tt.n.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/pmp.go
+++ b/openrtb2/pmp.go
@@ -36,3 +36,27 @@ type PMP struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the PMP object.
+func (p *PMP) Clone() *PMP {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+
+	// Deep copy deals
+	if p.Deals != nil {
+		clone.Deals = make([]Deal, len(p.Deals))
+		for i := range p.Deals {
+			clone.Deals[i] = *p.Deals[i].Clone()
+		}
+	}
+
+	// Deep copy ext
+	if p.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(p.Ext))
+		copy(clone.Ext, p.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/pmp_test.go
+++ b/openrtb2/pmp_test.go
@@ -1,0 +1,96 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPMP_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		p    *PMP
+	}{
+		{
+			name: "nil pmp",
+			p:    nil,
+		},
+		{
+			name: "empty pmp",
+			p:    &PMP{},
+		},
+		{
+			name: "fully populated pmp",
+			p: &PMP{
+				PrivateAuction: 1,
+				Deals: []Deal{
+					{
+						ID:          "deal1",
+						BidFloor:    1.23,
+						BidFloorCur: "USD",
+						AT:          1,
+						WSeat:       []string{"seat1", "seat2"},
+						WADomain:    []string{"domain1.com"},
+						Ext:         json.RawMessage(`{"deal_key": "value"}`),
+					},
+					{
+						ID:          "deal2",
+						BidFloor:    2.34,
+						BidFloorCur: "EUR",
+					},
+				},
+				Ext: json.RawMessage(`{"pmp_key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.p.Clone()
+
+			if tt.p == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil PMP")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.PrivateAuction != tt.p.PrivateAuction {
+				t.Errorf("Clone() PrivateAuction = %v, want %v", clone.PrivateAuction, tt.p.PrivateAuction)
+			}
+
+			// Test deals slice
+			if len(tt.p.Deals) > 0 {
+				if len(clone.Deals) != len(tt.p.Deals) {
+					t.Errorf("Clone() Deals length = %v, want %v", len(clone.Deals), len(tt.p.Deals))
+				}
+
+				// Test deep copy by modifying original
+				originalDealID := tt.p.Deals[0].ID
+				tt.p.Deals[0].ID = "modified"
+				if clone.Deals[0].ID != originalDealID {
+					t.Error("Clone() should create deep copy of Deals")
+				}
+
+				// Test nested slice deep copy
+				if len(tt.p.Deals[0].WSeat) > 0 {
+					originalSeat := tt.p.Deals[0].WSeat[0]
+					tt.p.Deals[0].WSeat[0] = "modified"
+					if clone.Deals[0].WSeat[0] != originalSeat {
+						t.Error("Clone() should create deep copy of Deal.WSeat")
+					}
+				}
+			}
+
+			// Test extension
+			if tt.p.Ext != nil {
+				orig := string(tt.p.Ext)
+				tt.p.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/producer.go
+++ b/openrtb2/producer.go
@@ -67,3 +67,20 @@ type Producer struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Producer
+func (p *Producer) Clone() *Producer {
+	if p == nil {
+		return nil
+	}
+
+	clone := *p
+
+	// Clone string slice
+	clone.Cat = cloneStringSlice(p.Cat)
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(p.Ext)
+
+	return &clone
+}

--- a/openrtb2/producer_test.go
+++ b/openrtb2/producer_test.go
@@ -1,0 +1,81 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestProducer_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		p    *Producer
+	}{
+		{
+			name: "nil producer",
+			p:    nil,
+		},
+		{
+			name: "empty producer",
+			p:    &Producer{},
+		},
+		{
+			name: "fully populated producer",
+			p: &Producer{
+				ID:     "prod1",
+				Name:   "Producer 1",
+				CatTax: adcom1.CategoryTaxonomy(1),
+				Cat:    []string{"IAB1", "IAB2"},
+				Domain: "producer.com",
+				Ext:    json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.p.Clone()
+
+			if tt.p == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Producer")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.p.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.p.ID)
+			}
+			if clone.Name != tt.p.Name {
+				t.Errorf("Clone() Name = %v, want %v", clone.Name, tt.p.Name)
+			}
+			if clone.Domain != tt.p.Domain {
+				t.Errorf("Clone() Domain = %v, want %v", clone.Domain, tt.p.Domain)
+			}
+			if clone.CatTax != tt.p.CatTax {
+				t.Errorf("Clone() CatTax = %v, want %v", clone.CatTax, tt.p.CatTax)
+			}
+
+			// Test slices
+			if len(tt.p.Cat) > 0 {
+				original := tt.p.Cat[0]
+				tt.p.Cat[0] = "modified"
+				if clone.Cat[0] != original {
+					t.Error("Clone() should create deep copy of Cat slice")
+				}
+			}
+
+			// Test deep copy of extension
+			if tt.p.Ext != nil {
+				orig := string(tt.p.Ext)
+				tt.p.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/publisher.go
+++ b/openrtb2/publisher.go
@@ -64,3 +64,20 @@ type Publisher struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Publisher
+func (p *Publisher) Clone() *Publisher {
+	if p == nil {
+		return nil
+	}
+
+	clone := *p
+
+	// Clone string slice
+	clone.Cat = cloneStringSlice(p.Cat)
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(p.Ext)
+
+	return &clone
+}

--- a/openrtb2/publisher_test.go
+++ b/openrtb2/publisher_test.go
@@ -1,0 +1,81 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestPublisher_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		p    *Publisher
+	}{
+		{
+			name: "nil publisher",
+			p:    nil,
+		},
+		{
+			name: "empty publisher",
+			p:    &Publisher{},
+		},
+		{
+			name: "fully populated publisher",
+			p: &Publisher{
+				ID:     "pub1",
+				Name:   "Publisher 1",
+				CatTax: adcom1.CategoryTaxonomy(1),
+				Cat:    []string{"IAB1", "IAB2"},
+				Domain: "publisher.com",
+				Ext:    json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.p.Clone()
+
+			if tt.p == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Publisher")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.p.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.p.ID)
+			}
+			if clone.Name != tt.p.Name {
+				t.Errorf("Clone() Name = %v, want %v", clone.Name, tt.p.Name)
+			}
+			if clone.Domain != tt.p.Domain {
+				t.Errorf("Clone() Domain = %v, want %v", clone.Domain, tt.p.Domain)
+			}
+			if clone.CatTax != tt.p.CatTax {
+				t.Errorf("Clone() CatTax = %v, want %v", clone.CatTax, tt.p.CatTax)
+			}
+
+			// Test slices
+			if len(tt.p.Cat) > 0 {
+				original := tt.p.Cat[0]
+				tt.p.Cat[0] = "modified"
+				if clone.Cat[0] != original {
+					t.Error("Clone() should create deep copy of Cat slice")
+				}
+			}
+
+			// Test deep copy of extension
+			if tt.p.Ext != nil {
+				orig := string(tt.p.Ext)
+				tt.p.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/qty.go
+++ b/openrtb2/qty.go
@@ -49,3 +49,20 @@ type Qty struct {
 	//   Placeholder for vendor specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the Qty object.
+func (q *Qty) Clone() *Qty {
+	if q == nil {
+		return nil
+	}
+
+	clone := *q
+
+	// Deep copy ext
+	if q.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(q.Ext))
+		copy(clone.Ext, q.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/refresh.go
+++ b/openrtb2/refresh.go
@@ -30,3 +30,34 @@ type Refresh struct {
 	//   Placeholder for vendor specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the Refresh object.
+func (r *Refresh) Clone() *Refresh {
+	if r == nil {
+		return nil
+	}
+
+	clone := *r
+
+	// Deep copy RefSettings
+	if r.RefSettings != nil {
+		clone.RefSettings = make([]RefSettings, len(r.RefSettings))
+		for i := range r.RefSettings {
+			clone.RefSettings[i] = *r.RefSettings[i].Clone()
+		}
+	}
+
+	// Deep copy Count
+	if r.Count != nil {
+		count := *r.Count
+		clone.Count = &count
+	}
+
+	// Deep copy ext
+	if r.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(r.Ext))
+		copy(clone.Ext, r.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/refresh_test.go
+++ b/openrtb2/refresh_test.go
@@ -1,0 +1,104 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestRefresh_Clone(t *testing.T) {
+	count := 2
+
+	tests := []struct {
+		name string
+		r    *Refresh
+	}{
+		{
+			name: "nil refresh",
+			r:    nil,
+		},
+		{
+			name: "empty refresh",
+			r:    &Refresh{},
+		},
+		{
+			name: "fully populated refresh",
+			r: &Refresh{
+				RefSettings: []RefSettings{
+					{
+						RefType: adcom1.AutoRefreshTriggerTime,
+						MinInt:  30,
+						Ext:     json.RawMessage(`{"refsettings_key":"value1"}`),
+					},
+					{
+						RefType: adcom1.AutoRefreshTriggerUserAction,
+						MinInt:  60,
+						Ext:     json.RawMessage(`{"refsettings_key":"value2"}`),
+					},
+				},
+				Count: &count,
+				Ext:   json.RawMessage(`{"refresh_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.r.Clone()
+
+			if tt.r == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Refresh")
+				}
+				return
+			}
+
+			// Test Count pointer
+			if tt.r.Count != nil {
+				if *clone.Count != *tt.r.Count {
+					t.Errorf("Clone() Count = %v, want %v", *clone.Count, *tt.r.Count)
+				}
+				oldCount := *tt.r.Count
+				*tt.r.Count = 99
+				if *clone.Count != oldCount {
+					t.Error("Clone() should create deep copy of Count")
+				}
+			}
+
+			// Test RefSettings slice
+			if len(tt.r.RefSettings) > 0 {
+				if len(clone.RefSettings) != len(tt.r.RefSettings) {
+					t.Errorf("Clone() RefSettings length = %v, want %v", len(clone.RefSettings), len(tt.r.RefSettings))
+				}
+
+				// Test deep copy of first RefSettings
+				originalRefType := tt.r.RefSettings[0].RefType
+				tt.r.RefSettings[0].RefType = adcom1.AutoRefreshTriggerUnknown
+				if clone.RefSettings[0].RefType != originalRefType {
+					t.Error("Clone() should create deep copy of RefSettings")
+				}
+
+				// Test RefSettings[0].Ext deep copy
+				if tt.r.RefSettings[0].Ext != nil {
+					orig := string(tt.r.RefSettings[0].Ext)
+					tt.r.RefSettings[0].Ext[0] = 'X'
+					clonedStr := string(clone.RefSettings[0].Ext)
+					if clonedStr != orig {
+						t.Error("Clone() should create deep copy of RefSettings[0].Ext")
+					}
+				}
+			}
+
+			// Test extension
+			if tt.r.Ext != nil {
+				orig := string(tt.r.Ext)
+				tt.r.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/refsettings.go
+++ b/openrtb2/refsettings.go
@@ -41,3 +41,20 @@ type RefSettings struct {
 	//   Placeholder for vendor specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the RefSettings object.
+func (r *RefSettings) Clone() *RefSettings {
+	if r == nil {
+		return nil
+	}
+
+	clone := *r
+
+	// Deep copy ext
+	if r.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(r.Ext))
+		copy(clone.Ext, r.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/refsettings_test.go
+++ b/openrtb2/refsettings_test.go
@@ -1,0 +1,63 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestRefSettings_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *RefSettings
+	}{
+		{
+			name: "nil refsettings",
+			r:    nil,
+		},
+		{
+			name: "empty refsettings",
+			r:    &RefSettings{},
+		},
+		{
+			name: "fully populated refsettings",
+			r: &RefSettings{
+				RefType: adcom1.AutoRefreshTriggerTime,
+				MinInt:  30,
+				Ext:     json.RawMessage(`{"refsettings_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.r.Clone()
+
+			if tt.r == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil RefSettings")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.RefType != tt.r.RefType {
+				t.Errorf("Clone() RefType = %v, want %v", clone.RefType, tt.r.RefType)
+			}
+			if clone.MinInt != tt.r.MinInt {
+				t.Errorf("Clone() MinInt = %v, want %v", clone.MinInt, tt.r.MinInt)
+			}
+
+			// Test extension
+			if tt.r.Ext != nil {
+				orig := string(tt.r.Ext)
+				tt.r.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/regs.go
+++ b/openrtb2/regs.go
@@ -67,3 +67,32 @@ type Regs struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the Regs object.
+func (r *Regs) Clone() *Regs {
+	if r == nil {
+		return nil
+	}
+
+	clone := *r
+
+	// Deep copy GDPR
+	if r.GDPR != nil {
+		gdpr := *r.GDPR
+		clone.GDPR = &gdpr
+	}
+
+	// Deep copy GPPSID
+	if r.GPPSID != nil {
+		clone.GPPSID = make([]int8, len(r.GPPSID))
+		copy(clone.GPPSID, r.GPPSID)
+	}
+
+	// Deep copy ext
+	if r.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(r.Ext))
+		copy(clone.Ext, r.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/regs_test.go
+++ b/openrtb2/regs_test.go
@@ -1,0 +1,93 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRegs_Clone(t *testing.T) {
+	gdpr := int8(1)
+
+	tests := []struct {
+		name string
+		r    *Regs
+	}{
+		{
+			name: "nil regs",
+			r:    nil,
+		},
+		{
+			name: "empty regs",
+			r:    &Regs{},
+		},
+		{
+			name: "fully populated regs",
+			r: &Regs{
+				COPPA:     1,
+				GDPR:      &gdpr,
+				USPrivacy: "1YNY",
+				GPP:       "DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+				GPPSID:    []int8{1, 2, 6},
+				Ext:       json.RawMessage(`{"regs_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.r.Clone()
+
+			if tt.r == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Regs")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.COPPA != tt.r.COPPA {
+				t.Errorf("Clone() COPPA = %v, want %v", clone.COPPA, tt.r.COPPA)
+			}
+			if clone.USPrivacy != tt.r.USPrivacy {
+				t.Errorf("Clone() USPrivacy = %v, want %v", clone.USPrivacy, tt.r.USPrivacy)
+			}
+			if clone.GPP != tt.r.GPP {
+				t.Errorf("Clone() GPP = %v, want %v", clone.GPP, tt.r.GPP)
+			}
+
+			// Test GDPR pointer
+			if tt.r.GDPR != nil {
+				if *clone.GDPR != *tt.r.GDPR {
+					t.Errorf("Clone() GDPR = %v, want %v", *clone.GDPR, *tt.r.GDPR)
+				}
+				oldGDPR := *tt.r.GDPR
+				*tt.r.GDPR = 0
+				if *clone.GDPR != oldGDPR {
+					t.Error("Clone() should create deep copy of GDPR")
+				}
+			}
+
+			// Test GPPSID slice
+			if len(tt.r.GPPSID) > 0 {
+				if len(clone.GPPSID) != len(tt.r.GPPSID) {
+					t.Errorf("Clone() GPPSID length = %v, want %v", len(clone.GPPSID), len(tt.r.GPPSID))
+				}
+				original := tt.r.GPPSID[0]
+				tt.r.GPPSID[0] = 99
+				if clone.GPPSID[0] != original {
+					t.Error("Clone() should create deep copy of GPPSID")
+				}
+			}
+
+			// Test extension
+			if tt.r.Ext != nil {
+				orig := string(tt.r.Ext)
+				tt.r.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/segment.go
+++ b/openrtb2/segment.go
@@ -41,3 +41,17 @@ type Segment struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Segment
+func (s *Segment) Clone() *Segment {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(s.Ext)
+
+	return &clone
+}

--- a/openrtb2/segment_test.go
+++ b/openrtb2/segment_test.go
@@ -1,0 +1,65 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSegment_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		s    *Segment
+	}{
+		{
+			name: "nil segment",
+			s:    nil,
+		},
+		{
+			name: "empty segment",
+			s:    &Segment{},
+		},
+		{
+			name: "fully populated segment",
+			s: &Segment{
+				ID:    "seg1",
+				Name:  "Segment 1",
+				Value: "value1",
+				Ext:   json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.s.Clone()
+
+			if tt.s == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Segment")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.s.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.s.ID)
+			}
+			if clone.Name != tt.s.Name {
+				t.Errorf("Clone() Name = %v, want %v", clone.Name, tt.s.Name)
+			}
+			if clone.Value != tt.s.Value {
+				t.Errorf("Clone() Value = %v, want %v", clone.Value, tt.s.Value)
+			}
+
+			// Test deep copy of extension
+			if tt.s.Ext != nil {
+				orig := string(tt.s.Ext)
+				tt.s.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/site.go
+++ b/openrtb2/site.go
@@ -175,3 +175,31 @@ type Site struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Site
+func (s *Site) Clone() *Site {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+
+	// Clone pointer fields
+	clone.Mobile = cloneInt8Ptr(s.Mobile)
+	clone.PrivacyPolicy = cloneInt8Ptr(s.PrivacyPolicy)
+
+	// Clone string slices
+	clone.Cat = cloneStringSlice(s.Cat)
+	clone.SectionCat = cloneStringSlice(s.SectionCat)
+	clone.PageCat = cloneStringSlice(s.PageCat)
+	clone.KwArray = cloneStringSlice(s.KwArray)
+
+	// Clone pointer objects
+	clone.Publisher = s.Publisher.Clone()
+	clone.Content = s.Content.Clone()
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(s.Ext)
+
+	return &clone
+}

--- a/openrtb2/site_test.go
+++ b/openrtb2/site_test.go
@@ -1,0 +1,137 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestSite_Clone(t *testing.T) {
+	var (
+		mobile        int8 = 1
+		privacyPolicy int8 = 1
+	)
+
+	tests := []struct {
+		name string
+		s    *Site
+	}{
+		{
+			name: "nil site",
+			s:    nil,
+		},
+		{
+			name: "empty site",
+			s:    &Site{},
+		},
+		{
+			name: "fully populated site",
+			s: &Site{
+				ID:            "site1",
+				Name:          "Test Site",
+				Domain:        "test.com",
+				CatTax:        adcom1.CategoryTaxonomy(1),
+				Cat:           []string{"IAB1", "IAB2"},
+				SectionCat:    []string{"IAB3", "IAB4"},
+				PageCat:       []string{"IAB5", "IAB6"},
+				Page:          "https://test.com/page",
+				Ref:           "https://referrer.com",
+				Search:        "test search",
+				Mobile:        &mobile,
+				PrivacyPolicy: &privacyPolicy,
+				Publisher: &Publisher{
+					ID:   "pub1",
+					Name: "Publisher 1",
+					Ext:  json.RawMessage(`{"key": "value"}`),
+				},
+				Content: &Content{
+					ID:    "content1",
+					Title: "Content Title",
+					Ext:   json.RawMessage(`{"key": "value"}`),
+				},
+				Keywords:               "test,site",
+				KwArray:                []string{"test", "site"},
+				InventoryPartnerDomain: "partner.com",
+				Ext:                    json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.s.Clone()
+
+			if tt.s == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Site")
+				}
+				return
+			}
+
+			// Test pointer fields
+			if tt.s.Mobile != nil {
+				orig := *tt.s.Mobile
+				*tt.s.Mobile = 0
+				if *clone.Mobile != orig {
+					t.Error("Clone() should create deep copy of Mobile")
+				}
+			}
+
+			// Test string slices
+			if len(tt.s.Cat) > 0 {
+				original := tt.s.Cat[0]
+				tt.s.Cat[0] = "modified"
+				if clone.Cat[0] != original {
+					t.Error("Clone() should create deep copy of Cat slice")
+				}
+			}
+
+			// Test Publisher
+			if tt.s.Publisher != nil {
+				origName := tt.s.Publisher.Name
+				tt.s.Publisher.Name = "modified"
+				if clone.Publisher.Name != origName {
+					t.Error("Clone() should create deep copy of Publisher")
+				}
+
+				if tt.s.Publisher.Ext != nil {
+					origExt := string(tt.s.Publisher.Ext)
+					tt.s.Publisher.Ext[0] = 'X'
+					clonedExt := string(clone.Publisher.Ext)
+					if clonedExt != origExt {
+						t.Error("Clone() should create deep copy of Publisher.Ext")
+					}
+				}
+			}
+
+			// Test Content
+			if tt.s.Content != nil {
+				origTitle := tt.s.Content.Title
+				tt.s.Content.Title = "modified"
+				if clone.Content.Title != origTitle {
+					t.Error("Clone() should create deep copy of Content")
+				}
+
+				if tt.s.Content.Ext != nil {
+					origExt := string(tt.s.Content.Ext)
+					tt.s.Content.Ext[0] = 'X'
+					clonedExt := string(clone.Content.Ext)
+					if clonedExt != origExt {
+						t.Error("Clone() should create deep copy of Content.Ext")
+					}
+				}
+			}
+
+			// Test extension
+			if tt.s.Ext != nil {
+				orig := string(tt.s.Ext)
+				tt.s.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/source.go
+++ b/openrtb2/source.go
@@ -55,3 +55,31 @@ type Source struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the Source object.
+func (s *Source) Clone() *Source {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+
+	// Deep copy FD
+	if s.FD != nil {
+		fd := *s.FD
+		clone.FD = &fd
+	}
+
+	// Deep copy SChain
+	if s.SChain != nil {
+		clone.SChain = s.SChain.Clone()
+	}
+
+	// Deep copy ext
+	if s.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(s.Ext))
+		copy(clone.Ext, s.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/source_test.go
+++ b/openrtb2/source_test.go
@@ -1,0 +1,132 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSource_Clone(t *testing.T) {
+	fd := int8(1)
+	hp := int8(1)
+
+	tests := []struct {
+		name string
+		s    *Source
+	}{
+		{
+			name: "nil source",
+			s:    nil,
+		},
+		{
+			name: "empty source",
+			s:    &Source{},
+		},
+		{
+			name: "fully populated source",
+			s: &Source{
+				FD:     &fd,
+				TID:    "transaction123",
+				PChain: "pchain123",
+				SChain: &SupplyChain{
+					Complete: 1,
+					Nodes: []SupplyChainNode{
+						{
+							ASI:    "ssp.example.com",
+							SID:    "seller123",
+							RID:    "request123",
+							Name:   "Example SSP",
+							Domain: "example.com",
+							HP:     &hp,
+							Ext:    json.RawMessage(`{"node_key":"value"}`),
+						},
+					},
+					Ver: "1.0",
+					Ext: json.RawMessage(`{"chain_key":"value"}`),
+				},
+				Ext: json.RawMessage(`{"source_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.s.Clone()
+
+			if tt.s == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Source")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.TID != tt.s.TID {
+				t.Errorf("Clone() TID = %v, want %v", clone.TID, tt.s.TID)
+			}
+			if clone.PChain != tt.s.PChain {
+				t.Errorf("Clone() PChain = %v, want %v", clone.PChain, tt.s.PChain)
+			}
+
+			// Test FD pointer
+			if tt.s.FD != nil {
+				if *clone.FD != *tt.s.FD {
+					t.Errorf("Clone() FD = %v, want %v", *clone.FD, *tt.s.FD)
+				}
+				oldFD := *tt.s.FD
+				*tt.s.FD = 0
+				if *clone.FD != oldFD {
+					t.Error("Clone() should create deep copy of FD")
+				}
+			}
+
+			// Test SChain
+			if tt.s.SChain != nil {
+				if clone.SChain == tt.s.SChain {
+					t.Error("Clone() should create a new pointer for SChain")
+				}
+				if tt.s.SChain.Complete != clone.SChain.Complete {
+					t.Errorf("Clone() SChain.Complete = %v, want %v", clone.SChain.Complete, tt.s.SChain.Complete)
+				}
+
+				// Test deep copy of chain's node
+				if len(tt.s.SChain.Nodes) > 0 {
+					originalASI := tt.s.SChain.Nodes[0].ASI
+					tt.s.SChain.Nodes[0].ASI = "modified"
+					if clone.SChain.Nodes[0].ASI != originalASI {
+						t.Error("Clone() should create deep copy of SChain.Nodes")
+					}
+
+					// Test node's extension
+					if tt.s.SChain.Nodes[0].Ext != nil {
+						orig := string(tt.s.SChain.Nodes[0].Ext)
+						tt.s.SChain.Nodes[0].Ext[0] = 'X'
+						clonedStr := string(clone.SChain.Nodes[0].Ext)
+						if clonedStr != orig {
+							t.Error("Clone() should create deep copy of SChain.Nodes[0].Ext")
+						}
+					}
+				}
+
+				// Test chain's extension
+				if tt.s.SChain.Ext != nil {
+					orig := string(tt.s.SChain.Ext)
+					tt.s.SChain.Ext[0] = 'X'
+					clonedStr := string(clone.SChain.Ext)
+					if clonedStr != orig {
+						t.Error("Clone() should create deep copy of SChain.Ext")
+					}
+				}
+			}
+
+			// Test extension
+			if tt.s.Ext != nil {
+				orig := string(tt.s.Ext)
+				tt.s.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/supply_chain.go
+++ b/openrtb2/supply_chain.go
@@ -50,3 +50,28 @@ type SupplyChain struct {
 	//   Placeholder for advertising-system specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the SupplyChain object.
+func (s *SupplyChain) Clone() *SupplyChain {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+
+	// Deep copy nodes
+	if s.Nodes != nil {
+		clone.Nodes = make([]SupplyChainNode, len(s.Nodes))
+		for i := range s.Nodes {
+			clone.Nodes[i] = *s.Nodes[i].Clone()
+		}
+	}
+
+	// Deep copy ext
+	if s.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(s.Ext))
+		copy(clone.Ext, s.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/supply_chain_node.go
+++ b/openrtb2/supply_chain_node.go
@@ -90,3 +90,26 @@ type SupplyChainNode struct {
 	//   Placeholder for advertising-system specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the SupplyChainNode object.
+func (n *SupplyChainNode) Clone() *SupplyChainNode {
+	if n == nil {
+		return nil
+	}
+
+	clone := *n
+
+	// Deep copy HP
+	if n.HP != nil {
+		hp := *n.HP
+		clone.HP = &hp
+	}
+
+	// Deep copy ext
+	if n.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(n.Ext))
+		copy(clone.Ext, n.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/supply_chain_node_test.go
+++ b/openrtb2/supply_chain_node_test.go
@@ -1,0 +1,88 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSupplyChainNode_Clone(t *testing.T) {
+	hp := int8(1)
+
+	tests := []struct {
+		name string
+		n    *SupplyChainNode
+	}{
+		{
+			name: "nil node",
+			n:    nil,
+		},
+		{
+			name: "empty node",
+			n:    &SupplyChainNode{},
+		},
+		{
+			name: "fully populated node",
+			n: &SupplyChainNode{
+				ASI:    "ssp.example.com",
+				SID:    "seller123",
+				RID:    "request123",
+				Name:   "Example SSP",
+				Domain: "example.com",
+				HP:     &hp,
+				Ext:    json.RawMessage(`{"node_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.n.Clone()
+
+			if tt.n == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil SupplyChainNode")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ASI != tt.n.ASI {
+				t.Errorf("Clone() ASI = %v, want %v", clone.ASI, tt.n.ASI)
+			}
+			if clone.SID != tt.n.SID {
+				t.Errorf("Clone() SID = %v, want %v", clone.SID, tt.n.SID)
+			}
+			if clone.RID != tt.n.RID {
+				t.Errorf("Clone() RID = %v, want %v", clone.RID, tt.n.RID)
+			}
+			if clone.Name != tt.n.Name {
+				t.Errorf("Clone() Name = %v, want %v", clone.Name, tt.n.Name)
+			}
+			if clone.Domain != tt.n.Domain {
+				t.Errorf("Clone() Domain = %v, want %v", clone.Domain, tt.n.Domain)
+			}
+
+			// Test HP pointer
+			if tt.n.HP != nil {
+				if *clone.HP != *tt.n.HP {
+					t.Errorf("Clone() HP = %v, want %v", *clone.HP, *tt.n.HP)
+				}
+				oldHP := *tt.n.HP
+				*tt.n.HP = 0
+				if *clone.HP != oldHP {
+					t.Error("Clone() should create deep copy of HP")
+				}
+			}
+
+			// Test extension
+			if tt.n.Ext != nil {
+				orig := string(tt.n.Ext)
+				tt.n.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/uid.go
+++ b/openrtb2/uid.go
@@ -38,3 +38,20 @@ type UID struct {
 	//   Placeholder for advertising-system specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the UID object.
+func (u *UID) Clone() *UID {
+	if u == nil {
+		return nil
+	}
+
+	clone := *u
+
+	// Deep copy ext
+	if u.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(u.Ext))
+		copy(clone.Ext, u.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/uid_test.go
+++ b/openrtb2/uid_test.go
@@ -1,0 +1,63 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestUID_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		u    *UID
+	}{
+		{
+			name: "nil uid",
+			u:    nil,
+		},
+		{
+			name: "empty uid",
+			u:    &UID{},
+		},
+		{
+			name: "fully populated uid",
+			u: &UID{
+				ID:    "uid123",
+				AType: adcom1.AgentTypeWeb,
+				Ext:   json.RawMessage(`{"uid_key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.u.Clone()
+
+			if tt.u == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil UID")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.u.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.u.ID)
+			}
+			if clone.AType != tt.u.AType {
+				t.Errorf("Clone() AType = %v, want %v", clone.AType, tt.u.AType)
+			}
+
+			// Test extension
+			if tt.u.Ext != nil {
+				orig := string(tt.u.Ext)
+				tt.u.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/user.go
+++ b/openrtb2/user.go
@@ -118,3 +118,47 @@ type User struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of the User object.
+func (u *User) Clone() *User {
+	if u == nil {
+		return nil
+	}
+
+	clone := *u
+
+	// Deep copy KwArray
+	if u.KwArray != nil {
+		clone.KwArray = make([]string, len(u.KwArray))
+		copy(clone.KwArray, u.KwArray)
+	}
+
+	// Deep copy Geo
+	if u.Geo != nil {
+		clone.Geo = u.Geo.Clone()
+	}
+
+	// Deep copy Data
+	if u.Data != nil {
+		clone.Data = make([]Data, len(u.Data))
+		for i := range u.Data {
+			clone.Data[i] = *u.Data[i].Clone()
+		}
+	}
+
+	// Deep copy EIDs
+	if u.EIDs != nil {
+		clone.EIDs = make([]EID, len(u.EIDs))
+		for i := range u.EIDs {
+			clone.EIDs[i] = *u.EIDs[i].Clone()
+		}
+	}
+
+	// Deep copy ext
+	if u.Ext != nil {
+		clone.Ext = make(json.RawMessage, len(u.Ext))
+		copy(clone.Ext, u.Ext)
+	}
+
+	return &clone
+}

--- a/openrtb2/user_agent.go
+++ b/openrtb2/user_agent.go
@@ -88,3 +88,31 @@ type UserAgent struct {
 	//   Placeholder for advertising-system specific extensions to this object.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of UserAgent
+func (u *UserAgent) Clone() *UserAgent {
+	if u == nil {
+		return nil
+	}
+
+	clone := *u
+
+	// Clone BrandVersion slice
+	if u.Browsers != nil {
+		clone.Browsers = make([]BrandVersion, len(u.Browsers))
+		for i := range u.Browsers {
+			clone.Browsers[i] = *u.Browsers[i].Clone()
+		}
+	}
+
+	// Clone Platform
+	clone.Platform = u.Platform.Clone()
+
+	// Clone pointer fields
+	clone.Mobile = cloneInt8Ptr(u.Mobile)
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(u.Ext)
+
+	return &clone
+}

--- a/openrtb2/user_agent_test.go
+++ b/openrtb2/user_agent_test.go
@@ -1,0 +1,145 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestUserAgent_Clone(t *testing.T) {
+	mobile := int8(1)
+
+	tests := []struct {
+		name string
+		ua   *UserAgent
+	}{
+		{
+			name: "nil user agent",
+			ua:   nil,
+		},
+		{
+			name: "empty user agent",
+			ua:   &UserAgent{},
+		},
+		{
+			name: "fully populated user agent",
+			ua: &UserAgent{
+				Browsers: []BrandVersion{
+					{
+						Brand:   "Chrome",
+						Version: []string{"91", "0", "4472"},
+						Ext:     json.RawMessage(`{"browser_key":"value"}`),
+					},
+					{
+						Brand:   "Firefox",
+						Version: []string{"89", "0"},
+						Ext:     json.RawMessage(`{"browser_key":"value2"}`),
+					},
+				},
+				Platform: &BrandVersion{
+					Brand:   "Windows",
+					Version: []string{"10", "0"},
+					Ext:     json.RawMessage(`{"platform_key":"value"}`),
+				},
+				Mobile:       &mobile,
+				Architecture: "x86",
+				Bitness:      "64",
+				Model:        "PC",
+				Source:       adcom1.UASourceHighEntropy,
+				Ext:          json.RawMessage(`{"ua_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.ua.Clone()
+
+			if tt.ua == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil UserAgent")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.Architecture != tt.ua.Architecture {
+				t.Errorf("Clone() Architecture = %v, want %v", clone.Architecture, tt.ua.Architecture)
+			}
+			if clone.Bitness != tt.ua.Bitness {
+				t.Errorf("Clone() Bitness = %v, want %v", clone.Bitness, tt.ua.Bitness)
+			}
+			if clone.Model != tt.ua.Model {
+				t.Errorf("Clone() Model = %v, want %v", clone.Model, tt.ua.Model)
+			}
+			if clone.Source != tt.ua.Source {
+				t.Errorf("Clone() Source = %v, want %v", clone.Source, tt.ua.Source)
+			}
+
+			// Test Browsers slice
+			if len(tt.ua.Browsers) > 0 {
+				if len(clone.Browsers) != len(tt.ua.Browsers) {
+					t.Errorf("Clone() Browsers length = %v, want %v", len(clone.Browsers), len(tt.ua.Browsers))
+				}
+				originalBrand := tt.ua.Browsers[0].Brand
+				tt.ua.Browsers[0].Brand = "modified"
+				if clone.Browsers[0].Brand != originalBrand {
+					t.Error("Clone() should create deep copy of Browsers")
+				}
+
+				// Test Browsers[0].Version slice
+				if len(tt.ua.Browsers[0].Version) > 0 {
+					originalVersion := tt.ua.Browsers[0].Version[0]
+					tt.ua.Browsers[0].Version[0] = "modified"
+					if clone.Browsers[0].Version[0] != originalVersion {
+						t.Error("Clone() should create deep copy of Browser Version")
+					}
+				}
+			}
+
+			// Test Platform
+			if tt.ua.Platform != nil {
+				if clone.Platform == tt.ua.Platform {
+					t.Error("Clone() should create a new pointer for Platform")
+				}
+				originalBrand := tt.ua.Platform.Brand
+				tt.ua.Platform.Brand = "modified"
+				if clone.Platform.Brand != originalBrand {
+					t.Error("Clone() should create deep copy of Platform")
+				}
+
+				// Test Platform Version slice
+				if len(tt.ua.Platform.Version) > 0 {
+					originalVersion := tt.ua.Platform.Version[0]
+					tt.ua.Platform.Version[0] = "modified"
+					if clone.Platform.Version[0] != originalVersion {
+						t.Error("Clone() should create deep copy of Platform Version")
+					}
+				}
+			}
+
+			// Test Mobile pointer
+			if tt.ua.Mobile != nil {
+				if *clone.Mobile != *tt.ua.Mobile {
+					t.Errorf("Clone() Mobile = %v, want %v", *clone.Mobile, *tt.ua.Mobile)
+				}
+				oldMobile := *tt.ua.Mobile
+				*tt.ua.Mobile = 0
+				if *clone.Mobile != oldMobile {
+					t.Error("Clone() should create deep copy of Mobile")
+				}
+			}
+
+			// Test extension
+			if tt.ua.Ext != nil {
+				orig := string(tt.ua.Ext)
+				tt.ua.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/user_test.go
+++ b/openrtb2/user_test.go
@@ -1,0 +1,149 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUser_Clone(t *testing.T) {
+	var (
+		yob int64   = 1990
+		lat float64 = 42.3601
+		lon float64 = -71.0589
+	)
+
+	tests := []struct {
+		name string
+		u    *User
+	}{
+		{
+			name: "nil user",
+			u:    nil,
+		},
+		{
+			name: "empty user",
+			u:    &User{},
+		},
+		{
+			name: "fully populated user",
+			u: &User{
+				ID:       "user1",
+				BuyerUID: "buyer123",
+				Yob:      yob,
+				Gender:   "M",
+				Keywords: "sports,news",
+				Geo: &Geo{
+					Lat:     &lat,
+					Lon:     &lon,
+					Type:    1,
+					City:    "Boston",
+					Region:  "MA",
+					Country: "USA",
+					Ext:     json.RawMessage(`{"geo_key":"value"}`),
+				},
+				EIDs: []EID{
+					{
+						Source: "example.com",
+						UIDs: []UID{
+							{
+								ID:    "uid123",
+								AType: 1,
+								Ext:   json.RawMessage(`{"uid_key":"value"}`),
+							},
+						},
+						Ext: json.RawMessage(`{"eid_key":"value"}`),
+					},
+				},
+				Data: []Data{
+					{
+						ID:   "data1",
+						Name: "Example Data",
+						Ext:  json.RawMessage(`{"data_key":"value"}`),
+					},
+				},
+				Consent: "GDPR-CONSENT",
+				Ext:     json.RawMessage(`{"user_key":"value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.u.Clone()
+
+			if tt.u == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil User")
+				}
+				return
+			}
+
+			// Test primitive fields
+			if clone.ID != tt.u.ID {
+				t.Errorf("Clone() ID = %v, want %v", clone.ID, tt.u.ID)
+			}
+			if clone.BuyerUID != tt.u.BuyerUID {
+				t.Errorf("Clone() BuyerUID = %v, want %v", clone.BuyerUID, tt.u.BuyerUID)
+			}
+			if clone.Yob != tt.u.Yob {
+				t.Errorf("Clone() Yob = %v, want %v", clone.Yob, tt.u.Yob)
+			}
+			if clone.Gender != tt.u.Gender {
+				t.Errorf("Clone() Gender = %v, want %v", clone.Gender, tt.u.Gender)
+			}
+			if clone.Keywords != tt.u.Keywords {
+				t.Errorf("Clone() Keywords = %v, want %v", clone.Keywords, tt.u.Keywords)
+			}
+			if clone.Consent != tt.u.Consent {
+				t.Errorf("Clone() Consent = %v, want %v", clone.Consent, tt.u.Consent)
+			}
+
+			// Test Geo
+			if tt.u.Geo != nil {
+				if clone.Geo == tt.u.Geo {
+					t.Error("Clone() should create a new pointer for Geo")
+				}
+				originalLat := *tt.u.Geo.Lat
+				newLat := float64(0)
+				tt.u.Geo.Lat = &newLat
+				if *clone.Geo.Lat != originalLat {
+					t.Error("Clone() should create deep copy of Geo")
+				}
+			}
+
+			// Test EIDs slice
+			if len(tt.u.EIDs) > 0 {
+				if len(clone.EIDs) != len(tt.u.EIDs) {
+					t.Errorf("Clone() EIDs length = %v, want %v", len(clone.EIDs), len(tt.u.EIDs))
+				}
+				originalSource := tt.u.EIDs[0].Source
+				tt.u.EIDs[0].Source = "modified"
+				if clone.EIDs[0].Source != originalSource {
+					t.Error("Clone() should create deep copy of EIDs")
+				}
+			}
+
+			// Test Data slice
+			if len(tt.u.Data) > 0 {
+				if len(clone.Data) != len(tt.u.Data) {
+					t.Errorf("Clone() Data length = %v, want %v", len(clone.Data), len(tt.u.Data))
+				}
+				originalID := tt.u.Data[0].ID
+				tt.u.Data[0].ID = "modified"
+				if clone.Data[0].ID != originalID {
+					t.Error("Clone() should create deep copy of Data")
+				}
+			}
+
+			// Test extension
+			if tt.u.Ext != nil {
+				orig := string(tt.u.Ext)
+				tt.u.Ext[0] = 'X'
+				clonedStr := string(clone.Ext)
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot: %q", orig, clonedStr)
+				}
+			}
+		})
+	}
+}

--- a/openrtb2/video.go
+++ b/openrtb2/video.go
@@ -400,3 +400,94 @@ type Video struct {
 	//   Placeholder for exchange-specific extensions to OpenRTB.
 	Ext json.RawMessage `json:"ext,omitempty"`
 }
+
+// Clone returns a deep copy of Video
+func (v *Video) Clone() *Video {
+	if v == nil {
+		return nil
+	}
+
+	clone := *v
+
+	// Clone string slices
+	clone.MIMEs = cloneStringSlice(v.MIMEs)
+
+	// Clone pointer fields
+	clone.StartDelay = cloneStartDelayPtr(v.StartDelay)
+	clone.W = cloneInt64Ptr(v.W)
+	clone.H = cloneInt64Ptr(v.H)
+	clone.Skip = cloneInt8Ptr(v.Skip)
+	clone.BoxingAllowed = cloneInt8Ptr(v.BoxingAllowed)
+	clone.Pos = clonePlacementPositionPtr(v.Pos)
+
+	// Clone integer slices
+	if v.RqdDurs != nil {
+		clone.RqdDurs = make([]int64, len(v.RqdDurs))
+		copy(clone.RqdDurs, v.RqdDurs)
+	}
+
+	// Clone adcom1 type slices
+	if v.Protocols != nil {
+		clone.Protocols = make([]adcom1.MediaCreativeSubtype, len(v.Protocols))
+		copy(clone.Protocols, v.Protocols)
+	}
+
+	if v.BAttr != nil {
+		clone.BAttr = make([]adcom1.CreativeAttribute, len(v.BAttr))
+		copy(clone.BAttr, v.BAttr)
+	}
+
+	if v.PlaybackMethod != nil {
+		clone.PlaybackMethod = make([]adcom1.PlaybackMethod, len(v.PlaybackMethod))
+		copy(clone.PlaybackMethod, v.PlaybackMethod)
+	}
+
+	if v.Delivery != nil {
+		clone.Delivery = make([]adcom1.DeliveryMethod, len(v.Delivery))
+		copy(clone.Delivery, v.Delivery)
+	}
+
+	if v.API != nil {
+		clone.API = make([]adcom1.APIFramework, len(v.API))
+		copy(clone.API, v.API)
+	}
+
+	if v.CompanionType != nil {
+		clone.CompanionType = make([]adcom1.CompanionType, len(v.CompanionType))
+		copy(clone.CompanionType, v.CompanionType)
+	}
+
+	if v.PodDedupe != nil {
+		clone.PodDedupe = make([]adcom1.PodDedupe, len(v.PodDedupe))
+		copy(clone.PodDedupe, v.PodDedupe)
+	}
+
+	// Clone Banner slice with deep copy
+	if v.CompanionAd != nil {
+		clone.CompanionAd = make([]Banner, len(v.CompanionAd))
+		for i := range v.CompanionAd {
+			clone.CompanionAd[i] = *v.CompanionAd[i].Clone()
+		}
+	}
+
+	// Clone DurFloors slice
+	if v.DurFloors != nil {
+		clone.DurFloors = make([]DurFloors, len(v.DurFloors))
+		for i := range v.DurFloors {
+			clone.DurFloors[i] = *v.DurFloors[i].Clone()
+		}
+	}
+
+	// Clone extension
+	clone.Ext = cloneRawMessage(v.Ext)
+
+	return &clone
+}
+
+func cloneStartDelayPtr(s *adcom1.StartDelay) *adcom1.StartDelay {
+	if s == nil {
+		return nil
+	}
+	clone := *s
+	return &clone
+}

--- a/openrtb2/video_test.go
+++ b/openrtb2/video_test.go
@@ -1,0 +1,141 @@
+package openrtb2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v20/adcom1"
+)
+
+func TestVideo_Clone(t *testing.T) {
+	var (
+		w             int64 = 640
+		h             int64 = 480
+		skip          int8  = 1
+		boxingAllowed int8  = 1
+		startDelay          = adcom1.StartDelay(0)
+		pos                 = adcom1.PlacementPosition(1)
+	)
+
+	tests := []struct {
+		name string
+		v    *Video
+	}{
+		{
+			name: "nil video",
+			v:    nil,
+		},
+		{
+			name: "empty video",
+			v:    &Video{},
+		},
+		{
+			name: "fully populated video",
+			v: &Video{
+				MIMEs:          []string{"video/mp4", "video/webm"},
+				MinDuration:    15,
+				MaxDuration:    30,
+				StartDelay:     &startDelay,
+				MaxSeq:         3,
+				PodDur:         90,
+				Protocols:      []adcom1.MediaCreativeSubtype{1, 2},
+				Protocol:       1,
+				W:              &w,
+				H:              &h,
+				PodID:          "pod123",
+				PodSeq:         1,
+				RqdDurs:        []int64{15, 30},
+				Placement:      1,
+				Plcmt:          1,
+				Linearity:      1,
+				Skip:           &skip,
+				SkipMin:        5,
+				SkipAfter:      5,
+				Sequence:       1,
+				SlotInPod:      1,
+				MinCPMPerSec:   1.5,
+				BAttr:          []adcom1.CreativeAttribute{1, 2},
+				MaxExtended:    60,
+				MinBitRate:     1000,
+				MaxBitRate:     2000,
+				BoxingAllowed:  &boxingAllowed,
+				PlaybackMethod: []adcom1.PlaybackMethod{1, 2},
+				PlaybackEnd:    1,
+				Delivery:       []adcom1.DeliveryMethod{1, 2},
+				Pos:            &pos,
+				CompanionAd: []Banner{
+					{
+						W:   &w,
+						H:   &h,
+						ID:  "banner1",
+						Ext: json.RawMessage(`{"key": "value"}`),
+					},
+				},
+				API:           []adcom1.APIFramework{1, 2},
+				CompanionType: []adcom1.CompanionType{1, 2},
+				PodDedupe:     []adcom1.PodDedupe{1, 2},
+				DurFloors:     []DurFloors{{MinDur: 15, BidFloor: 5.0}},
+				Ext:           json.RawMessage(`{"key": "value"}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := tt.v.Clone()
+
+			if tt.v == nil {
+				if clone != nil {
+					t.Error("Clone() should return nil for nil Video")
+				}
+				return
+			}
+
+			// Test deep copy of extension
+			if tt.v.Ext != nil {
+				orig := string(tt.v.Ext)       // Store original as string
+				tt.v.Ext[0] = 'X'              // Modify original
+				clonedStr := string(clone.Ext) // Get clone as string
+				if clonedStr != orig {
+					t.Errorf("Clone() Ext not properly copied\nwant: %q\ngot:  %q", orig, clonedStr)
+				}
+			}
+
+			// Test pointer fields
+			if tt.v.W != nil {
+				origW := *tt.v.W
+				*tt.v.W = 999
+				if *clone.W != origW {
+					t.Error("Clone() should create deep copy of W pointer")
+				}
+			}
+
+			// Test slices
+			if len(tt.v.MIMEs) > 0 {
+				original := tt.v.MIMEs[0]
+				tt.v.MIMEs[0] = "modified"
+				if clone.MIMEs[0] != original {
+					t.Error("Clone() should create deep copy of MIMEs slice")
+				}
+			}
+
+			// Test CompanionAd slice
+			if len(tt.v.CompanionAd) > 0 {
+				origID := tt.v.CompanionAd[0].ID
+				tt.v.CompanionAd[0].ID = "modified"
+				if clone.CompanionAd[0].ID != origID {
+					t.Error("Clone() should create deep copy of CompanionAd")
+				}
+			}
+
+			// Test DurFloors slice
+			if len(tt.v.DurFloors) > 0 {
+				origFloor := tt.v.DurFloors[0].BidFloor
+				tt.v.DurFloors[0].BidFloor = 999.99
+				if clone.DurFloors[0].BidFloor != origFloor {
+					t.Error("Clone() should create deep copy of DurFloors")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Added Clone methods to the following structures: Regs, Segment, Site, Source, SupplyChain, SupplyChainNode, UID, User, UserAgent, Video.
- Implemented unit tests for Clone methods to ensure deep copy behavior for all fields, including pointers and slices.
- Verified that modifications to original objects do not affect cloned objects, ensuring data integrity.