### PR TITLE
Fix typo in DataAssetTypeDisplayURL constant name

### DIFF
--- a/native1/data_asset_type.go
+++ b/native1/data_asset_type.go
@@ -129,7 +129,7 @@ const (
 	//   IE sponsored by BRAND on SITE (where SITE is transmitted in this field).
 	// Format:
 	//   text
-	DataAssetTypeDispayURL DataAssetType = 11
+	DataAssetTypeDisplayURL DataAssetType = 11
 
 	// Type ID:
 	//   12


### PR DESCRIPTION
## Summary
Fixed typo in constant name: `DataAssetTypeDispayURL` → `DataAssetTypeDisplayURL`

## Changes
- Corrected the spelling of the DisplayURL constant in `native1/data_asset_type.go`

## Test plan
- No functional changes, just a typo correction in the constant name
- Existing tests should continue to pass