### PR TITLE
Update IPLocationService type, add 51Degrees support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/adcom1/ip_location_service.go
+++ b/adcom1/ip_location_service.go
@@ -1,12 +1,14 @@
 package adcom1
 
 // IPLocationService represents services and/or vendors used for resolving IP addresses to geolocations.
-type IPLocationService int8
+type IPLocationService int16
 
 // Services and/or vendors used for resolving IP addresses to geolocations.
 const (
-	LocationServiceIP2Location IPLocationService = 1 // ip2location
-	LocationServiceNeustar     IPLocationService = 2 // Neustar (Quova)
-	LocationServiceMaxMind     IPLocationService = 3 // MaxMind
-	LocationServiceNetAcuity   IPLocationService = 4 // NetAcuity (Digital Element)
+	LocationServiceIP2Location               IPLocationService = 1   // ip2location
+	LocationServiceNeustar                   IPLocationService = 2   // Neustar (Quova)
+	LocationServiceMaxMind                   IPLocationService = 3   // MaxMind
+	LocationServiceNetAcuity                 IPLocationService = 4   // NetAcuity (Digital Element)
+	LocationService51DegreesHighConfidence   IPLocationService = 511 // 51Degrees (High Confidence)
+	LocationService51DegreesMediumConfidence IPLocationService = 512 // 51Degrees (Medium Confidence)
 )


### PR DESCRIPTION
`adcom1.IPLocationService` was defined as `int8` but [AdCOM 1.0](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list_iplocationservices) specifies values up to 512 (51Degrees entries).

Also updated the `actions/cache` version from 2 to 4  in the github workflow due to [package closing down](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down).
