### PR TITLE
AdCOM v1.0-202607

### DIFF
--- a/adcom1/category_taxonomy.go
+++ b/adcom1/category_taxonomy.go
@@ -14,4 +14,6 @@ const (
 	CatTaxIABContent21  CategoryTaxonomy = 5 // IAB Tech Lab Content Category Taxonomy 2.1.
 	CatTaxIABContent22  CategoryTaxonomy = 6 // IAB Tech Lab Content Category Taxonomy 2.2.
 	CatTaxIABContent30  CategoryTaxonomy = 7 // IAB Tech Lab Content Category Taxonomy 3.0.
+	CatTaxIABProduct20  CategoryTaxonomy = 8 // IAB Tech Lab Ad Product Taxonomy 2.0
+	CatTaxIABContent31  CategoryTaxonomy = 9 // IAB Tech Lab Content Category Taxonomy 3.1
 )

--- a/adcom1/content.go
+++ b/adcom1/content.go
@@ -67,6 +67,24 @@ type Content struct {
 	Genre string `json:"genre,omitempty"`
 
 	// Attribute:
+	//   gtax
+	// Type:
+	//   integer
+	// Definition:
+	//   The taxonomy in use.
+	//   If no gtax field is supplied, Content Category Taxonomy 3.1 is assumed
+	//   Refer to List: Category Taxonomies.
+	GTax CategoryTaxonomy `json:"gtax,omitempty"`
+
+	// Attribute:
+	//   genres
+	// Type:
+	//   string array
+	// Definition:
+	//   Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field.
+	Genres []string `json:"genres,omitempty"`
+
+	// Attribute:
 	//   album
 	// Type:
 	//   string
@@ -126,29 +144,29 @@ type Content struct {
 	Context ContentContext `json:"context,omitempty"`
 
 	// Attribute:
-	//   rating
+	//   contentrating
 	// Type:
 	//   string
 	// Definition:
 	//   Content rating (e.g., MPAA).
-	Rating string `json:"rating,omitempty"`
+	ContentRating string `json:"contentrating,omitempty"`
 
 	// Attribute:
-	//   urating
+	//   userrating
 	// Type:
 	//   string
 	// Definition:
 	//   User rating of the content (e.g., number of stars, likes, etc.).
-	URating string `json:"urating,omitempty"`
+	UserRating string `json:"userrating,omitempty"`
 
 	// Attribute:
-	//   mrating
+	//   qagmediarating
 	// Type:
 	//   integer
 	// Definition:
 	//   Media rating per IQG guidelines.
 	//   Refer to List: Media Ratings.
-	MRating MediaRating `json:"mrating,omitempty"`
+	QAGMediaMRating MediaRating `json:"qagmediarating,omitempty"`
 
 	// Attribute:
 	//   keywords
@@ -169,20 +187,20 @@ type Content struct {
 	KwArray []string `json:"kwarray,omitempty"`
 
 	// Attribute:
-	//   live
+	//   livestream
 	// Type:
 	//   integer
 	// Definition:
 	//   Indication of live content, where 0 = not live, 1 = live (e.g., stream, live blog).
-	Live int8 `json:"live,omitempty"`
+	LiveStream int8 `json:"livestream,omitempty"`
 
 	// Attribute:
-	//   srcrel
+	//   sourcerelationship
 	// Type:
 	//   integer
 	// Definition:
 	//   Source relationship, where 0 = indirect, 1 = direct.
-	SrcRel int8 `json:"srcrel,omitempty"`
+	SourceRelationship int8 `json:"sourcerelationship,omitempty"`
 
 	// Attribute:
 	//   len
@@ -193,20 +211,30 @@ type Content struct {
 	Len int64 `json:"len,omitempty"`
 
 	// Attribute:
-	//   lang
+	//   language
 	// Type:
 	//   string
 	// Definition:
 	//   Content language using ISO-639-1-alpha-2.
-	Lang string `json:"lang,omitempty"`
+	//   Only one of 'language' or 'langb' should be present.
+	Language string `json:"language,omitempty"`
 
 	// Attribute:
-	//   embed
+	//   langb
+	// Type:
+	//   string
+	// Definition:
+	//   Content language using IETF BCP 47.
+	//   Only one of 'language' or 'langb' should be present.
+	LangB string `json:"langb,omitempty"`
+
+	// Attribute:
+	//   embeddable
 	// Type:
 	//   integer
 	// Definition:
 	//   Indicator of whether or not the content is embedded off-site from the the site or app described in those objects (e.g., an embedded video player), where 0 = no, 1 = yes.
-	Embed int8 `json:"embed,omitempty"`
+	Embeddable int8 `json:"embeddable,omitempty"`
 
 	// Attribute:
 	//   producer
@@ -244,6 +272,22 @@ type Content struct {
 	//   Each Data object represents a different data source.
 	//   Refer to Object: Data.
 	Data []Data `json:"data,omitempty"`
+
+	// Attribute:
+	//   realtime
+	// Type:
+	//   integer
+	// Definition:
+	//   Indicator of whether or not the event is happening in real time, where 0 = not real time, 1 = real time
+	Realtime int8 `json:"realtime,omitempty"`
+
+	// Attribute:
+	//   firstbroadcast
+	// Type:
+	//   integer
+	// Definition:
+	//   Indicator of whether or not this broadcast is the first time the content is available to an audience, where 0 = not first broadcast, 1 = first broadcast
+	FirstBroadcast int8 `json:"firstbroadcast,omitempty"`
 
 	// Attribute:
 	//   ext

--- a/adcom1/content.go
+++ b/adcom1/content.go
@@ -67,6 +67,14 @@ type Content struct {
 	Genre string `json:"genre,omitempty"`
 
 	// Attribute:
+	//   genres
+	// Type:
+	//   string array
+	// Definition:
+	//   Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field.
+	Genres []string `json:"genres,omitempty"`
+
+	// Attribute:
 	//   gtax
 	// Type:
 	//   integer
@@ -75,14 +83,6 @@ type Content struct {
 	//   If no gtax field is supplied, Content Category Taxonomy 3.1 is assumed
 	//   Refer to List: Category Taxonomies.
 	GTax CategoryTaxonomy `json:"gtax,omitempty"`
-
-	// Attribute:
-	//   genres
-	// Type:
-	//   string array
-	// Definition:
-	//   Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field.
-	Genres []string `json:"genres,omitempty"`
 
 	// Attribute:
 	//   album
@@ -144,29 +144,29 @@ type Content struct {
 	Context ContentContext `json:"context,omitempty"`
 
 	// Attribute:
-	//   contentrating
+	//   rating
 	// Type:
 	//   string
 	// Definition:
 	//   Content rating (e.g., MPAA).
-	ContentRating string `json:"contentrating,omitempty"`
+	Rating string `json:"rating,omitempty"`
 
 	// Attribute:
-	//   userrating
+	//   urating
 	// Type:
 	//   string
 	// Definition:
 	//   User rating of the content (e.g., number of stars, likes, etc.).
-	UserRating string `json:"userrating,omitempty"`
+	URating string `json:"urating,omitempty"`
 
 	// Attribute:
-	//   qagmediarating
+	//   mrating
 	// Type:
 	//   integer
 	// Definition:
 	//   Media rating per IQG guidelines.
 	//   Refer to List: Media Ratings.
-	QAGMediaRating MediaRating `json:"qagmediarating,omitempty"`
+	MRating MediaRating `json:"mrating,omitempty"`
 
 	// Attribute:
 	//   keywords
@@ -187,20 +187,20 @@ type Content struct {
 	KwArray []string `json:"kwarray,omitempty"`
 
 	// Attribute:
-	//   livestream
+	//   live
 	// Type:
 	//   integer
 	// Definition:
 	//   Indication of live content, where 0 = not live, 1 = live (e.g., stream, live blog).
-	LiveStream int8 `json:"livestream,omitempty"`
+	Live int8 `json:"live,omitempty"`
 
 	// Attribute:
-	//   sourcerelationship
+	//   srcrel
 	// Type:
 	//   integer
 	// Definition:
 	//   Source relationship, where 0 = indirect, 1 = direct.
-	SourceRelationship int8 `json:"sourcerelationship,omitempty"`
+	SrcRel int8 `json:"srcrel,omitempty"`
 
 	// Attribute:
 	//   len
@@ -211,13 +211,13 @@ type Content struct {
 	Len int64 `json:"len,omitempty"`
 
 	// Attribute:
-	//   language
+	//   lang
 	// Type:
 	//   string
 	// Definition:
 	//   Content language using ISO-639-1-alpha-2.
-	//   Only one of 'language' or 'langb' should be present.
-	Language string `json:"language,omitempty"`
+	//   Only one of 'lang' or 'langb' should be present.
+	Lang string `json:"lang,omitempty"`
 
 	// Attribute:
 	//   langb
@@ -225,16 +225,16 @@ type Content struct {
 	//   string
 	// Definition:
 	//   Content language using IETF BCP 47.
-	//   Only one of 'language' or 'langb' should be present.
+	//   Only one of 'lang' or 'langb' should be present.
 	LangB string `json:"langb,omitempty"`
 
 	// Attribute:
-	//   embeddable
+	//   embed
 	// Type:
 	//   integer
 	// Definition:
 	//   Indicator of whether or not the content is embedded off-site from the the site or app described in those objects (e.g., an embedded video player), where 0 = no, 1 = yes.
-	Embeddable int8 `json:"embeddable,omitempty"`
+	Embed int8 `json:"embed,omitempty"`
 
 	// Attribute:
 	//   producer

--- a/adcom1/content.go
+++ b/adcom1/content.go
@@ -166,7 +166,7 @@ type Content struct {
 	// Definition:
 	//   Media rating per IQG guidelines.
 	//   Refer to List: Media Ratings.
-	QAGMediaMRating MediaRating `json:"qagmediarating,omitempty"`
+	QAGMediaRating MediaRating `json:"qagmediarating,omitempty"`
 
 	// Attribute:
 	//   keywords

--- a/adcom1/creative_attribute.go
+++ b/adcom1/creative_attribute.go
@@ -25,4 +25,9 @@ const (
 	AttrHasSkipButton          CreativeAttribute = 16 // Ad Provides Skip Button (e.g. VPAID-rendered skip button on pre-roll video)
 	AttrFlash                  CreativeAttribute = 17 // Adobe Flash
 	AttrResponsive             CreativeAttribute = 18 // Responsive; Sizeless; Fluid (i.e., creatives that dynamically resize to environment)
+	AttrQRCode                 CreativeAttribute = 19 // Contains advertiser QR Code
+	AttrAlphaChannel           CreativeAttribute = 20 // Support alpha channel transparency
+	AttrStatic                 CreativeAttribute = 21 // Static Visual. Creative contains no perceptible motion and renders as a static visual, even if delivered in a video file format (e.g., MP4)
+	AttrLimitedMotion          CreativeAttribute = 22 // Limited Motion (Cinemagraph). Creative contains subtle or localized motion within an otherwise static composition.
+	AttrFullMotion             CreativeAttribute = 23 // Full-Motion Video. Creative contains continuous or scene-level motion typical of standard video assets
 )

--- a/adcom1/data.go
+++ b/adcom1/data.go
@@ -23,6 +23,14 @@ type Data struct {
 	Name string `json:"name,omitempty"`
 
 	// Attribute:
+	//   cids
+	// Type:
+	//   string array
+	// Definition:
+	//   Array of Extended Content IDs, representing one or more identifiers for the video or audio content from the ID source specified in the 'name' field of the 'data' object.
+	CIDs []string `json:"cids,omitempty"`
+
+	// Attribute:
 	//   segment
 	// Type:
 	//   object array

--- a/adcom1/extended_identifier.go
+++ b/adcom1/extended_identifier.go
@@ -24,6 +24,35 @@ type ExtendedIdentifier struct {
 	UIDs []ExtendedIdentifierUID `json:"uids,omitempty"`
 
 	// Attribute:
+	//   inserter
+	// Type:
+	//   string
+	// Definition:
+	//   The canonical domain name of the entity (publisher, publisher monetization company, SSP, Exchange, Header Wrapper, etc.) that caused the ID array element to be added.
+	//   This should be the same value as used to identify sellers in an ads.txt file if one exists.
+	//   For ad tech intermediaries, this would be the domain as used in ads.txt. For publishers, this would match the domain in the 'site' or 'app' object.
+	Inserter string `json:"inserter,omitempty"`
+
+	// Attribute:
+	//   matcher
+	// Type:
+	//   string
+	// Definition:
+	//   Technology providing the match method as defined in 'mm'.
+	//   In some cases, this may be the same value as inserter.
+	//   When blank, it is assumed that the 'matcher' is equal to the 'source'.
+	//   May be omitted when mm=0, 1, or 2.
+	Matcher string `json:"matcher,omitempty"`
+
+	// Attribute:
+	//   mm
+	// Type:
+	//   integer
+	// Definition:
+	//   Match method used by the matcher. Refer to List: ID Match Methods
+	MM MatchMethod `json:"mm,omitempty"`
+
+	// Attribute:
 	//   ext
 	// Type:
 	//   object

--- a/adcom1/match_method.go
+++ b/adcom1/match_method.go
@@ -5,6 +5,8 @@ package adcom1
 type MatchMethod int64
 
 // Various ways an ID could be matched to an ad request
+//
+// Values of 500+ hold vendor-specific codes.
 const (
 	MatchMethodUnknown           MatchMethod = 0
 	MatchMethodNoMatch           MatchMethod = 1 // No matching has occurred. The associated ID came directly from a 3rd-party cookie or OS-provided resettable device ID for advertising (IFA).

--- a/adcom1/placement_position.go
+++ b/adcom1/placement_position.go
@@ -6,14 +6,24 @@ type PlacementPosition int8
 
 // Placement positions.
 const (
-	PositionUnknown    PlacementPosition = 0 // Unknown
-	PositionAboveFold  PlacementPosition = 1 // Above The Fold
-	PositionLocked     PlacementPosition = 2 // Locked (i.e., fixed position)
-	PositionBelowFold  PlacementPosition = 3 // Below The Fold
-	PositionHeader     PlacementPosition = 4 // Header
-	PositionFooter     PlacementPosition = 5 // Footer
-	PositionSideBar    PlacementPosition = 6 // Sidebar
-	PositionFullScreen PlacementPosition = 7 // Fullscreen
+	PositionUnknown                 PlacementPosition = 0  // Unknown
+	PositionAboveFold               PlacementPosition = 1  // Above The Fold
+	PositionLocked                  PlacementPosition = 2  // Locked (i.e., fixed position)
+	PositionBelowFold               PlacementPosition = 3  // Below The Fold
+	PositionHeader                  PlacementPosition = 4  // Header
+	PositionFooter                  PlacementPosition = 5  // Footer
+	PositionSideBar                 PlacementPosition = 6  // Sidebar
+	PositionFullScreen              PlacementPosition = 7  // Fullscreen
+	PositionPartial                 PlacementPosition = 8  // Partial Screen
+	PositionTopLeft                 PlacementPosition = 9  // Top Left
+	PositionTopRight                PlacementPosition = 10 // Top Right
+	PositionFrame                   PlacementPosition = 11 // Frame the content
+	PositionDoubleBox               PlacementPosition = 12 // Double box
+	PositionDoubleBoxWithBackground PlacementPosition = 13 // Double box with background
+	PositionBottomLeft              PlacementPosition = 14 // Bottom Left
+	PositionBottomRight             PlacementPosition = 15 // Bottom Right
+	PositionLShape                  PlacementPosition = 16 // L shape
+	PositionReverseLShape           PlacementPosition = 17 // Reversed L shape
 )
 
 // Ptr returns pointer to own value.

--- a/adcom1/playback_method.go
+++ b/adcom1/playback_method.go
@@ -5,11 +5,15 @@ type PlaybackMethod int8
 
 // Media playback methods.
 const (
-	PlaybackPageLoadSoundOn  PlaybackMethod = 1 // Initiates on Page Load with Sound On
-	PlaybackPageLoadSoundOff PlaybackMethod = 2 // Initiates on Page Load with Sound Off by Default
-	PlaybackClickSoundOn     PlaybackMethod = 3 // Initiates on Click with Sound On
-	PlaybackMouseOverSoundOn PlaybackMethod = 4 // Initiates on Mouse-Over with Sound On
-	PlaybackViewportSoundOn  PlaybackMethod = 5 // Initiates on Entering Viewport with Sound On
-	PlaybackViewportSoundOff PlaybackMethod = 6 // Initiates on Entering Viewport with Sound Off by Default
-	PlaybackContinuous       PlaybackMethod = 7 // Continuous Playback - Media playback is set to play additional media automatically without user interaction. The media player will keep playing additional media (playlist or generated) for the user until the user actively stops this from happening.
+	PlaybackPageLoadSoundOn  PlaybackMethod = 1  // Initiates without any specific user interaction with Sound On
+	PlaybackPageLoadSoundOff PlaybackMethod = 2  // Initiates without any specific user interaction Sound Off by Default
+	PlaybackClickSoundOn     PlaybackMethod = 3  // Initiates on Click with Sound On
+	PlaybackMouseOverSoundOn PlaybackMethod = 4  // Initiates on Mouse-Over or cursor over with Sound On
+	PlaybackViewportSoundOn  PlaybackMethod = 5  // Initiates on Entering Viewport or scrolling into view with Sound On
+	PlaybackViewportSoundOff PlaybackMethod = 6  // Initiates on Entering Viewport or scrolling into view with Sound Off by Default
+	PlaybackContinuous       PlaybackMethod = 7  // Continuous Playback - Media playback is set to play additional media automatically without user interaction. The media player will keep playing additional media (playlist or generated) for the user until the user actively stops this from happening.
+	PlaybackPauseSoundOn     PlaybackMethod = 8  // Initiated by user pausing content, Sound on
+	PlaybackPauseSoundOff    PlaybackMethod = 9  // Initiated by user pausing content, Sound off
+	PlaybackIdlingsoundOn    PlaybackMethod = 10 // Initiated by idling (e.g. screensaver), Sound on
+	PlaybackIdlingSoundOff   PlaybackMethod = 11 // Initiated by idling (e.g. screensaver), Sound off
 )

--- a/adcom1/regs.go
+++ b/adcom1/regs.go
@@ -23,6 +23,26 @@ type Regs struct {
 	GDPR int8 `json:"gdpr,omitempty"`
 
 	// Attribute:
+	//   gpp
+	// Type:
+	//   string
+	// Definition:
+	//   Contains the Global Privacy Platform’s consent string.
+	//   See the Global Privacy Platform specification for more details.
+	GPP string `json:"gpp,omitempty"`
+
+	// Attribute:
+	//   gpp_sid
+	// Type:
+	//   integer array
+	// Definition:
+	//   Array of the section(s) of the string which should be applied for this transaction.
+	//   Generally will contain one and only one value, but there are edge cases where more than one may apply.
+	//   GPP Section 3 (Header) and 4 (Signal Integrity) do not need to be included.
+	//   See the GPP Section Information for more details.
+	GPPSID []int8 `json:"gpp_sid,omitempty"`
+
+	// Attribute:
 	//   ext
 	// Type:
 	//   object

--- a/adcom1/restrictions.go
+++ b/adcom1/restrictions.go
@@ -5,6 +5,14 @@ import "encoding/json"
 // Restrictions object allows lists of restrictions on ad responses to be specified including specific content categories, advertisers, ads pertaining to specific apps, or creative attributes.
 type Restrictions struct {
 	// Attribute:
+	//   acat
+	// Type:
+	//   string array
+	// Definition:
+	//   Allowed content categories using IDs from the taxonomy indicated in cattax.
+	ACat []string `json:"acat,omitempty"`
+
+	// Attribute:
 	//   bcat
 	// Type:
 	//   string array

--- a/adcom1/video_placement_subtype.go
+++ b/adcom1/video_placement_subtype.go
@@ -8,9 +8,13 @@ type VideoPlacementSubtype int8
 
 // Types of video placements derived largely from the IAB Digital Video Guidelines.
 const (
-	VideoPlacementInStream      VideoPlacementSubtype = 1 // In-Stream: Played before, during or after the streaming video content that the consumer has requested (e.g., Pre-roll, Mid-roll, Post-roll).
-	VideoPlacementInBanner      VideoPlacementSubtype = 2 // In-Banner: Exists within a web banner that leverages the banner space to deliver a video experience as opposed to another static or rich media format. The format relies on the existence of display ad inventory on the page for its delivery.
-	VideoPlacementInArticle     VideoPlacementSubtype = 3 // In-Article: Loads and plays dynamically between paragraphs of editorial content; existing as a standalone branded message.
-	VideoPlacementInFeed        VideoPlacementSubtype = 4 // In-Feed: Found in content, social, or product feeds.
-	VideoPlacementAlwaysVisible VideoPlacementSubtype = 5 // Interstitial/Slider/Floating: Covers the entire or a portion of screen area, but is always on screen while displayed (i.e. cannot be scrolled out of view).
+	VideoPlacementInStream            VideoPlacementSubtype = 1 // In-Stream: Played before, during or after the streaming video content that the consumer has requested (e.g., Pre-roll, Mid-roll, Post-roll).
+	VideoPlacementAccompanyingContent VideoPlacementSubtype = 2 // Accompanying Content: Pre-roll, mid-roll, and post-roll ads that are played before, during, or after streaming video content.
+	VideoPlacementInterstitial        VideoPlacementSubtype = 3 // Interstitial: Video ads that are played without video content.
+	VideoPlacementNoContent           VideoPlacementSubtype = 4 // No Content/Standalone: Video ads that are played without streaming video content.
+	VideoPlacementPause               VideoPlacementSubtype = 5 // Pause: An ad present in streaming video content that the consumer has requested.
+	VideoPlacementScreensaver         VideoPlacementSubtype = 6 // Screensaver: An ad present, when OS/App Screen Saver are initiated.
+	VideoPlacementOverlay             VideoPlacementSubtype = 7 // Overlay: Ads occurring during program content and outside of the traditional ad break.
+	VideoPlacementSqueezeback         VideoPlacementSubtype = 8 // Squeezeback: Ads Alongside or Adjacent to Content, also known as L-Shape Ads & Double Box, are ads that occur during program content and outside of the traditional ad break.
+	VideoPlacementInScene             VideoPlacementSubtype = 9 // In-scene: A form of advertising that integrates branded elements directly within the content itself, rather than appearing as separate pre-roll, mid-roll, overlay, or display formats.
 )


### PR DESCRIPTION
* [AdCOM v1.0-202607](https://github.com/InteractiveAdvertisingBureau/AdCOM/releases/tag/AdCOM1.0-202607)

# Further reading

* also includes updates from AdCOM v1.0-202606
* ~~breaks compatiblity with previous module, and requires new module version (v21?)~~
* does not include but should require #18 
* includes updates to `VideoPlacementSubtype` even though it was deprecated in 2023