### PR TITLE
OpenRTB 2.6-202501 + 2.6-202505 + 2.6-202606

### DIFF
--- a/adcom1/category_taxonomy.go
+++ b/adcom1/category_taxonomy.go
@@ -14,4 +14,6 @@ const (
 	CatTaxIABContent21  CategoryTaxonomy = 5 // IAB Tech Lab Content Category Taxonomy 2.1.
 	CatTaxIABContent22  CategoryTaxonomy = 6 // IAB Tech Lab Content Category Taxonomy 2.2.
 	CatTaxIABContent30  CategoryTaxonomy = 7 // IAB Tech Lab Content Category Taxonomy 3.0.
+	CatTaxIABProduct20  CategoryTaxonomy = 8 // IAB Tech Lab Ad Product Taxonomy 2.0.
+	CatTaxIABContent31  CategoryTaxonomy = 9 // IAB Tech Lab Content Taxonomy 3.1.
 )

--- a/adcom1/content.go
+++ b/adcom1/content.go
@@ -11,7 +11,7 @@ type Content struct {
 	// Type:
 	//   string
 	// Definition:
-	//   ID uniquely identifying the content.
+	//   Publisher-provided ID uniquely identifying the content.
 	ID string `json:"id,omitempty"`
 
 	// Attribute:
@@ -61,10 +61,28 @@ type Content struct {
 	// Attribute:
 	//   genre
 	// Type:
-	//   string
+	//   string; DEPRECATED
 	// Definition:
 	//   Genre that best describes the content (e.g., rock, pop, etc).
+	//   NOTE: this field is deprecated, use 'genres' instead.
 	Genre string `json:"genre,omitempty"`
+
+	// Attribute:
+	//   genres
+	// Type:
+	//   string array
+	// Definition:
+	//   Array of genre IDs that describe the content using IDs from the taxonomy indicated in gtax.
+	Genres []string `json:"genres,omitempty"`
+
+	// Attribute:
+	//   gtax
+	// Type:
+	//   integer; default 9
+	// Definition:
+	//   The taxonomy in use for the genres attribute.
+	//   Refer to List: Category Taxonomies.
+	GTax CategoryTaxonomy `json:"gtax,omitempty"`
 
 	// Attribute:
 	//   album
@@ -173,7 +191,9 @@ type Content struct {
 	// Type:
 	//   integer
 	// Definition:
-	//   Indication of live content, where 0 = not live, 1 = live (e.g., stream, live blog).
+	//   An enumeration indicating the method of broadcast of the content where:
+	//   0 = the broadcast is not scheduled (e.g. it is VOD or otherwise user initiated).
+	//   1 = the broadcast is scheduled (also referred to as linear viewing).
 	Live int8 `json:"live,omitempty"`
 
 	// Attribute:
@@ -244,6 +264,26 @@ type Content struct {
 	//   Each Data object represents a different data source.
 	//   Refer to Object: Data.
 	Data []Data `json:"data,omitempty"`
+
+	// Attribute:
+	//   realtime
+	// Type:
+	//   integer
+	// Definition:
+	//   An enumeration indicating if the event is happening in real time while it is being watched where:
+	//   0 = not happening in real time (e.g., a replay).
+	//   1 = yes, happening in real time (e.g., a live sports game).
+	Realtime int8 `json:"realtime,omitempty"`
+
+	// Attribute:
+	//   firstbroadcast
+	// Type:
+	//   integer
+	// Definition:
+	//   An enumeration indicating whether this broadcast is the first time the content is available to an audience where:
+	//   0 = not first time being broadcast
+	//   1 = first time being broadcast
+	FirstBroadcast int8 `json:"firstbroadcast,omitempty"`
 
 	// Attribute:
 	//   ext

--- a/adcom1/data.go
+++ b/adcom1/data.go
@@ -23,6 +23,16 @@ type Data struct {
 	Name string `json:"name,omitempty"`
 
 	// Attribute:
+	//   cids
+	// Type:
+	//   string array
+	// Definition:
+	//   An array of Extended Content IDs, representing one or more identifiers
+	//   for the video or audio content from the ID source specified in the name
+	//   field of the data object.
+	CIDs []string `json:"cids,omitempty"`
+
+	// Attribute:
 	//   segment
 	// Type:
 	//   object array

--- a/openrtb2/audio.go
+++ b/openrtb2/audio.go
@@ -116,9 +116,7 @@ type Audio struct {
 	// Type:
 	//   integer; default 0; DEPRECATED
 	// Description:
-	//   If multiple ad impressions are offered in the same bid request,
-	//   the sequence number will allow for the coordinated delivery
-	//   of multiple creatives.
+	//   Deprecated as of OpenRTB 2.6. Use slotinpod.
 	Sequence int64 `json:"sequence,omitempty"`
 
 	// Attribute:

--- a/openrtb2/bid.go
+++ b/openrtb2/bid.go
@@ -215,9 +215,7 @@ type Bid struct {
 	// Type:
 	//   integer; DEPRECATED
 	// Description:
-	//   NOTE: Deprecated in favor of the apis integer array.
-	//   API required by the markup if applicable. Refer to List: API
-	//   Frameworks in AdCOM 1.0.
+	//   NOTE: Deprecated in favor of apis.
 	// Note:
 	//   OpenRTB <=2.5 defined only frameworks 1..6.
 	API adcom1.APIFramework `json:"api,omitempty"`

--- a/openrtb2/content.go
+++ b/openrtb2/content.go
@@ -19,7 +19,7 @@ type Content struct {
 	// Type:
 	//   string
 	// Description:
-	//   ID uniquely identifying the content.
+	//   Publisher-provided ID uniquely identifying the content.
 	ID string `json:"id,omitempty"`
 
 	// Attribute:
@@ -76,6 +76,29 @@ type Content struct {
 	// Description:
 	//   Genre that best describes the content (e.g., rock, pop, etc).
 	Genre string `json:"genre,omitempty"`
+
+	// Attribute:
+	//   gtax
+	// Type:
+	//   integer; default 9
+	// Description:
+	//   The taxonomy in use. Refer to the AdCOM list List: Category
+	//   Taxonomies for values. If no gtax field is supplied, Content
+	//   Category Taxonomy 3.1 is assumed.
+	GTax adcom1.CategoryTaxonomy `json:"gtax,omitempty"`
+
+	// Attribute:
+	//   genres
+	// Type:
+	//   string array
+	// Description:
+	//   Unique ID(s) for the genre of the content as listed in the
+	//   taxonomy defined by the gtax field. If no gtax field is
+	//   supplied, subset of rows listed in CTV Genre Mapping of
+	//   Content Category Taxonomy 3.1 are assumed.
+	//   See Section 7.13 in Implementation Guidance for additional
+	//   detail.
+	Genres []string `json:"genres,omitempty"`
 
 	// Attribute:
 	//   album
@@ -204,7 +227,12 @@ type Content struct {
 	// Type:
 	//   integer
 	// Description:
-	//   0 = not live, 1 = content is live (e.g., stream, live blog).
+	//   An enumeration indicating the method of broadcast of the
+	//   content where:
+	//   0 = the broadcast is not scheduled (e.g. it is VOD or otherwise
+	//   user initiated).
+	//   1 = the broadcast is scheduled (also referred to as linear
+	//   viewing).
 	LiveStream *int8 `json:"livestream,omitempty"`
 
 	// Attribute:
@@ -274,6 +302,28 @@ type Content struct {
 	// Description:
 	//   Details about the channel (Section 3.2.24) the content is on.
 	Channel *Channel `json:"channel,omitempty"`
+
+	// Attribute:
+	//   realtime
+	// Type:
+	//   integer
+	// Description:
+	//   An enumeration indicating if the event is happening in real
+	//   time while it is being watched where:
+	//   0 = not happening in real time (e.g., a replay).
+	//   1 = yes, happening in real time (e.g., a live sports game).
+	Realtime *int8 `json:"realtime,omitempty"`
+
+	// Attribute:
+	//   firstbroadcast
+	// Type:
+	//   integer
+	// Description:
+	//   An enumeration indicating whether this broadcast is the first
+	//   time the content is available to an audience where:
+	//   0 = not first time being broadcast
+	//   1 = first time being broadcast
+	FirstBroadcast *int8 `json:"firstbroadcast,omitempty"`
 
 	// Attribute:
 	//   ext

--- a/openrtb2/data.go
+++ b/openrtb2/data.go
@@ -27,6 +27,16 @@ type Data struct {
 	Name string `json:"name,omitempty"`
 
 	// Attribute:
+	//   cids
+	// Type:
+	//   string array
+	// Description:
+	//   An array of Extended Content IDs, representing one or more
+	//   identifiers for the video or audio content from the ID source
+	//   specified in the name field of the data object.
+	CIDs []string `json:"cids,omitempty"`
+
+	// Attribute:
 	//   segment
 	// Type:
 	//   object array

--- a/openrtb2/device.go
+++ b/openrtb2/device.go
@@ -277,7 +277,7 @@ type Device struct {
 	// Type:
 	//   string; DEPRECATED
 	// Description:
-	//   Hardware device ID (e.g., IMEI); hashed via SHA1.
+	//   Deprecated as of OpenRTB 2.6.
 	DIDSHA1 string `json:"didsha1,omitempty"`
 
 	// Attribute:
@@ -285,7 +285,7 @@ type Device struct {
 	// Type:
 	//   string; DEPRECATED
 	// Description:
-	//  Hardware device ID (e.g., IMEI); hashed via MD5.
+	//   Deprecated as of OpenRTB 2.6.
 	DIDMD5 string `json:"didmd5,omitempty"`
 
 	// Attribute:
@@ -293,7 +293,7 @@ type Device struct {
 	// Type:
 	//   string; DEPRECATED
 	// Description:
-	//   Platform device ID (e.g., Android ID); hashed via SHA1.
+	//   Deprecated as of OpenRTB 2.6.
 	DPIDSHA1 string `json:"dpidsha1,omitempty"`
 
 	// Attribute:
@@ -301,7 +301,7 @@ type Device struct {
 	// Type:
 	//   string; DEPRECATED
 	// Description:
-	//   Platform device ID (e.g., Android ID); hashed via MD5.
+	//   Deprecated as of OpenRTB 2.6.
 	DPIDMD5 string `json:"dpidmd5,omitempty"`
 
 	// Attribute:
@@ -309,7 +309,7 @@ type Device struct {
 	// Type:
 	//   string; DEPRECATED
 	// Description:
-	//   MAC address of the device; hashed via SHA1.
+	//   Deprecated as of OpenRTB 2.6.
 	MACSHA1 string `json:"macsha1,omitempty"`
 
 	// Attribute:
@@ -317,7 +317,7 @@ type Device struct {
 	// Type:
 	//   string; DEPRECATED
 	// Description:
-	//   MAC address of the device; hashed via MD5.
+	//   Deprecated as of OpenRTB 2.6.
 	MACMD5 string `json:"macmd5,omitempty"`
 
 	// Attribute:

--- a/openrtb2/user.go
+++ b/openrtb2/user.go
@@ -36,7 +36,7 @@ type User struct {
 	// Type:
 	//   integer; DEPRECATED
 	// Description:
-	//   Year of birth as a 4-digit integer.
+	//   Deprecated as of OpenRTB 2.6.
 	Yob int64 `json:"yob,omitempty"`
 
 	// Attribute:
@@ -44,8 +44,7 @@ type User struct {
 	// Type:
 	//   string; DEPRECATED
 	// Description:
-	//   Gender, where “M” = male, “F” = female, “O” = known to be
-	//   other (i.e., omitted is unknown).
+	//   Deprecated as of OpenRTB 2.6.
 	Gender string `json:"gender,omitempty"`
 
 	// Attribute:

--- a/openrtb2/video.go
+++ b/openrtb2/video.go
@@ -162,8 +162,7 @@ type Video struct {
 	// Type:
 	//   integer; DEPRECATED
 	// Description:
-	//   Video placement type for the impression. Refer to List:
-	//   Placement Subtypes - Video in AdCOM 1.0.
+	//   Deprecated as of OpenRTB 2.6-202303. Use plcmt instead.
 	Placement adcom1.VideoPlacementSubtype `json:"placement,omitempty"`
 
 	// Attribute:
@@ -222,9 +221,7 @@ type Video struct {
 	// Type:
 	//   integer; default 0; DEPRECATED
 	// Description:
-	//   If multiple ad impressions are offered in the same bid request,
-	//   the sequence number will allow for the coordinated delivery
-	//   of multiple creatives.
+	//   Deprecated as of OpenRTB 2.6. Use slotinpod.
 	Sequence int8 `json:"sequence,omitempty"`
 
 	// Attribute:


### PR DESCRIPTION
## Summary

Brings `openrtb2` and `adcom1` up to date with the OpenRTB 2.6 releases published since [2.6-202409](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/releases/tag/2.6-202409), plus the associated AdCOM spec updates. All changes are additive or comment-only; no fields were removed and no types changed.

### [2.6-202501](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/releases/tag/2.6-202501)
- Add `gtax` and `genres` attributes to `Object: Content`
- Update descriptions of deprecated attributes (video/audio `sequence`, video `placement`, device hashed IDs, user `yob`/`gender`, bid `api`), noting deprecation version and replacement attribute where applicable
- Add Content Taxonomy 3.1 (9) to AdCOM `List: Category Taxonomies`, along with Ad Product Taxonomy 2.0 (8) which was previously missing from the list

### [2.6-202505](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/releases/tag/2.6-202505)
- Update `content.id` attribute description
- Add `cids` attribute to `Object: Data` (OpenRTB and AdCOM)
- `genres` errata: type is string array (added directly as `[]string` here, so the int array from 202501 never lands)
- Sync AdCOM `Object: Content` with `genres`/`gtax`, deprecating `genre`

### [2.6-202606](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/releases/tag/2.6-202606)
- Add `realtime` and `firstbroadcast` attributes to OpenRTB `Object: Content` and AdCOM `Object: Content`
- Update attribute description of `content.livestream` (and AdCOM `content.live`)
- The substitution macro additions in this release are documentation-only, so no library changes

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)

Made with [Cursor](https://cursor.com)